### PR TITLE
Consume data API client nuget

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,3 @@
+# Copy to create .env file
+
 DEFRA_NUGET_PAT=[pat]

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,1 @@
-DEFRA_NUGET_USERNAME=[github username]
 DEFRA_NUGET_PAT=[pat]

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+DEFRA_NUGET_USERNAME=[github username]
+DEFRA_NUGET_PAT=[pat]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,11 @@
 version: 2
 
+registries:
+  defra:
+    type: nuget-feed
+    url: https://nuget.pkg.github.com/DEFRA/index.json
+    token: ${{ secrets.DEPENDABOT_PAT }}
+
 updates:
   - package-ecosystem: nuget
     directory: /
@@ -19,6 +25,7 @@ updates:
           - "minor"
     allow:
       - dependency-type: direct
+    registries: "*"
 
   - package-ecosystem: github-actions
     directory: /

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -25,7 +25,8 @@ jobs:
             9.0
       - name: Update NuGet.config
         run: |
-          dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
+          dotnet nuget remove source defra
+          dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name defra "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
       - name: Test
         run: dotnet test
       - name: Check Dockerfile Builds

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Update NuGet.config
         run: |
           dotnet nuget remove source defra
-          dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name defra "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
+          dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name defra "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --configfile NuGet.config
       - name: Test
         run: dotnet test
       - name: Check Dockerfile Builds
@@ -36,7 +36,6 @@ jobs:
           file: ./Dockerfile
           push: false
           tags: trade-imports-decision-comparer:latest
-          build-args: DEFRA_NUGET_PAT=${{ secrets.GITHUB_TOKEN }}
       - name: Check with Trivy
         run: docker run -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy image trade-imports-decision-comparer:latest --ignore-unfixed
   sonarcloud-scan:

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -18,12 +18,16 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-      - name: Test
+      - name: Setup dotnet
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
             9.0
-      - run: dotnet test
+      - name: Update NuGet.config
+        run: |
+          dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
+      - name: Test
+        run: dotnet test
       - name: Check Dockerfile Builds
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4
         with:
@@ -31,6 +35,7 @@ jobs:
           file: ./Dockerfile
           push: false
           tags: trade-imports-decision-comparer:latest
+          build-args: DEFRA_NUGET_PAT=${{ secrets.GITHUB_TOKEN }}
       - name: Check with Trivy
         run: docker run -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy image trade-imports-decision-comparer:latest --ignore-unfixed
   sonarcloud-scan:

--- a/.github/workflows/publish-hotfix.yml
+++ b/.github/workflows/publish-hotfix.yml
@@ -22,6 +22,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Depth 0 required for branch-based versioning
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            9.0
+      - name: Update NuGet.config
+        run: |
+          dotnet nuget remove source defra
+          dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name defra "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --configfile NuGet.config
       - name: Publish Hot Fix
         uses: DEFRA/cdp-build-action/build-hotfix@main
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,7 @@ permissions:
   id-token: write
   contents: write
   pull-requests: write
+  packages: read
 
 env:
   AWS_REGION: eu-west-2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,15 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            9.0
+      - name: Update NuGet.config
+        run: |
+          dotnet nuget remove source defra
+          dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name defra "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --configfile NuGet.config
       - name: Build and Publish
         uses: DEFRA/cdp-build-action/build@main
         with:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -68,4 +68,5 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           ./.sonar/scanner/dotnet-sonarscanner begin /k:"DEFRA_trade-imports-decision-comparer" /o:"defra" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml
+          dotnet restore --configfile NuGet.config
           ./.sonar/scanner/dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -66,5 +66,6 @@ jobs:
           ./.sonar/scanner/dotnet-sonarscanner begin /k:"DEFRA_trade-imports-decision-comparer" /o:"defra" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml
           dotnet nuget remove source defra
           dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name defra "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --configfile NuGet.config
+          cat NuGet.config
           dotnet restore --configfile NuGet.config
           ./.sonar/scanner/dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -27,10 +27,6 @@ jobs:
         with:
           dotnet-version: |
             9.0
-      - name: Update NuGet.config
-        run: |
-          dotnet nuget remove source defra
-          dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name defra "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --configfile NuGet.config
       - name: Cache SonarCloud packages
         uses: actions/cache@v4
         with:
@@ -68,5 +64,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           ./.sonar/scanner/dotnet-sonarscanner begin /k:"DEFRA_trade-imports-decision-comparer" /o:"defra" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml
-          dotnet restore --configfile NuGet.config
+          dotnet nuget remove source defra
+          dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name defra "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --configfile NuGet.config
+          dotnet restore
           ./.sonar/scanner/dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           ./.sonar/scanner/dotnet-sonarscanner begin /k:"DEFRA_trade-imports-decision-comparer" /o:"defra" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml
           dotnet nuget remove source defra
-          dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name defra "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --configfile NuGet.config
+          dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name defra "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
           dotnet build --no-incremental
           ./.sonar/coverage/dotnet-coverage collect "dotnet test" -f xml -o "coverage.xml"
           ./.sonar/scanner/dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -67,6 +67,6 @@ jobs:
           ./.sonar/scanner/dotnet-sonarscanner begin /k:"DEFRA_trade-imports-decision-comparer" /o:"defra" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml
           dotnet nuget remove source defra
           dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name defra "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --configfile NuGet.config
-          cat NuGet.config
-          dotnet restore --configfile NuGet.config --verbosity detailed
+          dotnet build --no-incremental
+          ./.sonar/coverage/dotnet-coverage collect "dotnet test" -f xml -o "coverage.xml"
           ./.sonar/scanner/dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -68,6 +68,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           ./.sonar/scanner/dotnet-sonarscanner begin /k:"DEFRA_trade-imports-decision-comparer" /o:"defra" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml
-          dotnet build --no-incremental
+          dotnet restore --configfile NuGet.config
+          dotnet build --no-incremental --no-restore
           ./.sonar/coverage/dotnet-coverage collect "dotnet test" -f xml -o "coverage.xml"
           ./.sonar/scanner/dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -7,6 +7,7 @@ permissions:
   id-token: write
   contents: read
   pull-requests: write
+  packages: read
 
 jobs:
   build:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -67,5 +67,5 @@ jobs:
           dotnet nuget remove source defra
           dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name defra "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --configfile NuGet.config
           cat NuGet.config
-          dotnet restore --configfile NuGet.config
+          dotnet restore --configfile NuGet.config --verbosity detailed
           ./.sonar/scanner/dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -68,7 +68,4 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           ./.sonar/scanner/dotnet-sonarscanner begin /k:"DEFRA_trade-imports-decision-comparer" /o:"defra" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml
-          dotnet restore --configfile NuGet.config
-          dotnet build --no-incremental --no-restore
-          ./.sonar/coverage/dotnet-coverage collect "dotnet test" -f xml -o "coverage.xml"
           ./.sonar/scanner/dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -66,5 +66,5 @@ jobs:
           ./.sonar/scanner/dotnet-sonarscanner begin /k:"DEFRA_trade-imports-decision-comparer" /o:"defra" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml
           dotnet nuget remove source defra
           dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name defra "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --configfile NuGet.config
-          dotnet restore
+          dotnet restore --configfile NuGet.config
           ./.sonar/scanner/dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -27,6 +27,10 @@ jobs:
         with:
           dotnet-version: |
             9.0
+      - name: Update NuGet.config
+        run: |
+          dotnet nuget remove source defra
+          dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name defra "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --configfile NuGet.config
       - name: Cache SonarCloud packages
         uses: actions/cache@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -271,3 +271,5 @@ library.db
 openapi.json
 
 *.received.*
+
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ WORKDIR /src
 
 COPY .config/dotnet-tools.json .config/dotnet-tools.json
 COPY .csharpierrc .csharpierrc
+COPY NuGet.config NuGet.config
+ARG DEFRA_NUGET_PAT
 
 RUN dotnet tool restore
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,6 @@ WORKDIR /src
 
 COPY .config/dotnet-tools.json .config/dotnet-tools.json
 COPY .csharpierrc .csharpierrc
-COPY NuGet.config NuGet.config
-ARG DEFRA_NUGET_PAT
 
 RUN dotnet tool restore
 
@@ -29,6 +27,9 @@ COPY tests/Comparer.Tests/Comparer.Tests.csproj tests/Comparer.Tests/Comparer.Te
 COPY tests/Comparer.IntegrationTests/Comparer.IntegrationTests.csproj tests/Comparer.IntegrationTests/Comparer.IntegrationTests.csproj
 COPY Defra.TradeImportsDecisionComparer.sln Defra.TradeImportsDecisionComparer.sln
 COPY Directory.Build.props Directory.Build.props
+COPY NuGet.config NuGet.config
+RUN cat NuGet.config
+ARG DEFRA_NUGET_PAT
 
 RUN dotnet restore
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,6 @@ COPY Defra.TradeImportsDecisionComparer.sln Defra.TradeImportsDecisionComparer.s
 COPY Directory.Build.props Directory.Build.props
 
 COPY NuGet.config NuGet.config
-RUN cat NuGet.config
 ARG DEFRA_NUGET_PAT
 
 RUN dotnet restore

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ COPY tests/Comparer.Tests/Comparer.Tests.csproj tests/Comparer.Tests/Comparer.Te
 COPY tests/Comparer.IntegrationTests/Comparer.IntegrationTests.csproj tests/Comparer.IntegrationTests/Comparer.IntegrationTests.csproj
 COPY Defra.TradeImportsDecisionComparer.sln Defra.TradeImportsDecisionComparer.sln
 COPY Directory.Build.props Directory.Build.props
+
 COPY NuGet.config NuGet.config
 RUN cat NuGet.config
 ARG DEFRA_NUGET_PAT

--- a/NuGet.config
+++ b/NuGet.config
@@ -5,4 +5,10 @@
         <add key="nuget" value="https://api.nuget.org/v3/index.json" />
         <add key="defra" value="https://nuget.pkg.github.com/DEFRA/index.json" />
     </packageSources>
+    <packageSourceCredentials>
+        <defra>
+            <add key="Username" value="none" />
+            <add key="ClearTextPassword" value="%DEFRA_NUGET_PAT%" />
+        </defra>
+    </packageSourceCredentials>
 </configuration>

--- a/NuGet.config
+++ b/NuGet.config
@@ -7,7 +7,7 @@
     </packageSources>
     <packageSourceCredentials>
         <defra>
-            <add key="Username" value="none" />
+            <add key="Username" value="%DEFRA_NUGET_USERNAME%" />
             <add key="ClearTextPassword" value="%DEFRA_NUGET_PAT%" />
         </defra>
     </packageSourceCredentials>

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageSources>
+        <clear />
+        <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+        <add key="defra" value="https://nuget.pkg.github.com/DEFRA/index.json" />
+    </packageSources>
+</configuration>

--- a/NuGet.config
+++ b/NuGet.config
@@ -7,7 +7,7 @@
     </packageSources>
     <packageSourceCredentials>
         <defra>
-            <add key="Username" value="%DEFRA_NUGET_USERNAME%" />
+            <add key="Username" value="USERNAME" />
             <add key="ClearTextPassword" value="%DEFRA_NUGET_PAT%" />
         </defra>
     </packageSourceCredentials>

--- a/src/Comparer/Comparer.csproj
+++ b/src/Comparer/Comparer.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Defra.TradeImportsDataApi.Api.Client" Version="0.1.0-pr-18.100" />
+    <PackageReference Include="Defra.TradeImportsDataApi.Api.Client" Version="0.1.0" />
     <PackageReference Include="Elastic.CommonSchema.Serilog" Version="8.12.3" />
     <PackageReference Include="Elastic.Serilog.Enrichers.Web" Version="8.12.3" />
     <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="9.0.3" />

--- a/src/Comparer/Comparer.csproj
+++ b/src/Comparer/Comparer.csproj
@@ -18,6 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Defra.TradeImportsDataApi.Api.Client" Version="0.1.0-pr-18.92" />
     <PackageReference Include="Elastic.CommonSchema.Serilog" Version="8.12.3" />
     <PackageReference Include="Elastic.Serilog.Enrichers.Web" Version="8.12.3" />
     <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="9.0.3" />

--- a/src/Comparer/Comparer.csproj
+++ b/src/Comparer/Comparer.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Defra.TradeImportsDataApi.Api.Client" Version="0.1.0-pr-18.92" />
+    <PackageReference Include="Defra.TradeImportsDataApi.Api.Client" Version="0.1.0-pr-18.100" />
     <PackageReference Include="Elastic.CommonSchema.Serilog" Version="8.12.3" />
     <PackageReference Include="Elastic.Serilog.Enrichers.Web" Version="8.12.3" />
     <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="9.0.3" />


### PR DESCRIPTION
This PR is tracking the new API client in development and ensuring the package can be pulled from GitHub actions as well as locally.

We will need to create a personal PAT token (classic version) and give it the `read:packages` permission.

It can then be used locally in development to authenticate against the package feed. You can login with password as your PAT token (username does not matter). See `.env.example` for guidance.

For Windows and Visual Studio, standard user environment variables can be added.

We can improve this experience over time!