### PR TITLE
Trigger comparison check when an MRN is finalised

### DIFF
--- a/Defra.TradeImportsDecisionComparer.sln.DotSettings
+++ b/Defra.TradeImportsDecisionComparer.sln.DotSettings
@@ -1,4 +1,7 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=alvs/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=appsettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=btms/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=enricher/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=finalisations/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=gmrs/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/compose.yml
+++ b/compose.yml
@@ -32,6 +32,10 @@ services:
     depends_on:
       mongodb:
         condition: service_healthy
+      localstack:
+        condition: service_healthy
+      wiremock:
+        condition: service_started
     env_file:
       - 'compose/aws.env'
     environment:
@@ -39,6 +43,8 @@ services:
       ENVIRONMENT: local
       PORT: 8080
       Mongo__DatabaseUri: mongodb://mongodb:27017/?directConnection=true
+      DataApi__BaseAddress: "http://wiremock"
+      SQS_ENDPOINT: http://localstack:4566
     ports:
       - "8080:8080"
     healthcheck:
@@ -47,6 +53,35 @@ services:
       timeout: 5s
       retries: 10
       start_period: 5s
+  
+  localstack:
+    image: localstack/localstack
+    ports:
+      - '4566:4566' # LocalStack Gateway
+      - '4510-4559:4510-4559' # external services port range
+    env_file:
+      - 'compose/aws.env'
+    environment:
+      DEBUG: ${DEBUG:-1}
+      LS_LOG: info # Localstack DEBUG Level
+      SERVICES: sqs
+      LOCALSTACK_HOST: 127.0.0.1
+      TZ: Europe/London
+    volumes:
+      - '${TMPDIR:-/tmp}/localstack:/var/lib/localstack'
+      - ./compose/start-localstack.sh:/etc/localstack/init/ready.d/start-localstack.sh
+    healthcheck:
+      test: cat /tmp/ready
+      interval: 5s
+      start_period: 5s
+      retries: 10
+  
+  wiremock:
+    environment:
+      TZ: Europe/London
+    image: sheyenrath/wiremock.net:latest
+    ports:
+      - "9090:80"
 
 volumes:
   mongodb-data:

--- a/compose/start-localstack.sh
+++ b/compose/start-localstack.sh
@@ -1,11 +1,22 @@
 #!/bin/bash
+
+export AWS_ENDPOINT_URL=http://localhost:4566
 export AWS_REGION=eu-west-2
 export AWS_DEFAULT_REGION=eu-west-2
 export AWS_ACCESS_KEY_ID=test
 export AWS_SECRET_ACCESS_KEY=test
 
-# S3 buckets
-# aws --endpoint-url=http://localhost:4566 s3 mb s3://my-bucket
+aws --endpoint-url=http://localhost:4566 sqs create-queue \
+    --queue-name trade_imports_data_upserted_decision_comparer
 
-# SQS queues
-# aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name my-queue
+function is_ready() {
+    aws --endpoint-url=http://localhost:4566 sqs get-queue-url --queue-name trade_imports_data_upserted_decision_comparer || return 1
+    return 0
+}
+
+while ! is_ready; do
+    echo "Waiting until ready"
+    sleep 1
+done
+
+touch /tmp/ready

--- a/src/Comparer/Comparer.csproj
+++ b/src/Comparer/Comparer.csproj
@@ -30,5 +30,8 @@
     <PackageReference Include="MongoDB.Driver" Version="3.3.0" />
     <PackageReference Include="AspNetCore.HealthChecks.MongoDb" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="2.1.0" />
+    <PackageReference Include="SlimMessageBus" Version="3.0.0" />
+    <PackageReference Include="SlimMessageBus.Host.AmazonSQS" Version="3.1.1" />
+    <PackageReference Include="SlimMessageBus.Host.Serialization.SystemTextJson" Version="3.1.0" />
   </ItemGroup>
 </Project>

--- a/src/Comparer/Comparer.csproj
+++ b/src/Comparer/Comparer.csproj
@@ -15,7 +15,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Defra.TradeImportsDataApi.Api.Client" Version="0.8.0" />
+    <PackageReference Include="Defra.TradeImportsDataApi.Api.Client" Version="0.11.0" />
     <PackageReference Include="Elastic.CommonSchema.Serilog" Version="8.12.3" />
     <PackageReference Include="Elastic.Serilog.Enrichers.Web" Version="8.12.3" />
     <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="9.0.4" />

--- a/src/Comparer/Configuration/FinalisationsConsumerOptions.cs
+++ b/src/Comparer/Configuration/FinalisationsConsumerOptions.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Defra.TradeImportsDecisionComparer.Comparer.Configuration;
+
+public class FinalisationsConsumerOptions
+{
+    public const string SectionName = "FinalisationsConsumer";
+
+    [Required]
+    public required string QueueName { get; init; }
+
+    // This is only turned off in appsettings.IntegrationTests.json currently
+    // as we don't want the consumers running for in memory integration tests.
+    public required bool Enabled { get; init; } = true;
+}

--- a/src/Comparer/Consumers/FinalisationsConsumer.cs
+++ b/src/Comparer/Consumers/FinalisationsConsumer.cs
@@ -1,0 +1,20 @@
+using System.Text.Json;
+using SlimMessageBus;
+using SlimMessageBus.Host.AmazonSQS;
+
+namespace Defra.TradeImportsDecisionComparer.Comparer.Consumers;
+
+// ReSharper disable once ClassNeverInstantiated.Global
+public class FinalisationsConsumer(ILogger<FinalisationsConsumer> logger) : IConsumer<JsonElement>, IConsumerWithContext
+{
+    private string MessageId => Context.GetTransportMessage().MessageId;
+
+    public Task OnHandle(JsonElement received, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Consumed {MessageId}", MessageId);
+
+        return Task.CompletedTask;
+    }
+
+    public required IConsumerContext Context { get; set; }
+}

--- a/src/Comparer/Consumers/FinalisationsConsumer.cs
+++ b/src/Comparer/Consumers/FinalisationsConsumer.cs
@@ -1,19 +1,47 @@
 using System.Text.Json;
+using Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
+using Defra.TradeImportsDataApi.Domain.Events;
+using Defra.TradeImportsDecisionComparer.Comparer.Domain;
+using Defra.TradeImportsDecisionComparer.Comparer.Entities;
+using Defra.TradeImportsDecisionComparer.Comparer.Services;
 using SlimMessageBus;
 using SlimMessageBus.Host.AmazonSQS;
 
 namespace Defra.TradeImportsDecisionComparer.Comparer.Consumers;
 
 // ReSharper disable once ClassNeverInstantiated.Global
-public class FinalisationsConsumer(ILogger<FinalisationsConsumer> logger) : IConsumer<JsonElement>, IConsumerWithContext
+public class FinalisationsConsumer(
+    IDecisionService decisionService,
+    IComparisonService comparisonService,
+    ILogger<FinalisationsConsumer> logger
+) : IConsumer<JsonElement>, IConsumerWithContext
 {
     private string MessageId => Context.GetTransportMessage().MessageId;
 
-    public Task OnHandle(JsonElement received, CancellationToken cancellationToken)
+    public async Task OnHandle(JsonElement received, CancellationToken cancellationToken)
     {
         logger.LogInformation("Consumed {MessageId}", MessageId);
 
-        return Task.CompletedTask;
+        var message =
+            received.Deserialize<ResourceEvent<CustomsDeclaration>>()
+            ?? throw new InvalidOperationException("Could not deserialize resource event");
+
+        logger.LogInformation("Processing {MessageId} for {ResourceId}", MessageId, message.ResourceId);
+
+        var alvsDecision = await decisionService.GetAlvsDecision(message.ResourceId, cancellationToken);
+        var btmsDecision = await decisionService.GetBtmsDecision(message.ResourceId, cancellationToken);
+        var latestAlvs = alvsDecision?.Decisions.LastOrDefault();
+        var latestBtms = btmsDecision?.Decisions.LastOrDefault();
+
+        var comparison =
+            await comparisonService.Get(message.ResourceId, cancellationToken)
+            ?? new ComparisonEntity { Id = message.ResourceId, Comparisons = [] };
+
+        comparison.Comparisons.Add(
+            new Comparison(DateTime.UtcNow, latestAlvs?.Xml, latestBtms?.Xml, false, Reasons: null)
+        );
+
+        await comparisonService.Save(comparison, cancellationToken);
     }
 
     public required IConsumerContext Context { get; set; }

--- a/src/Comparer/Data/IDbContext.cs
+++ b/src/Comparer/Data/IDbContext.cs
@@ -6,5 +6,6 @@ public interface IDbContext
 {
     IMongoCollectionSet<AlvsDecisionEntity> AlvsDecisions { get; }
     IMongoCollectionSet<BtmsDecisionEntity> BtmsDecisions { get; }
+    IMongoCollectionSet<ComparisonEntity> Comparisons { get; }
     Task SaveChangesAsync(CancellationToken cancellation = default);
 }

--- a/src/Comparer/Data/Mongo/MongoDbContext.cs
+++ b/src/Comparer/Data/Mongo/MongoDbContext.cs
@@ -12,6 +12,7 @@ public class MongoDbContext : IDbContext
         Database = database;
         AlvsDecisions = new MongoCollectionSet<AlvsDecisionEntity>(this);
         BtmsDecisions = new MongoCollectionSet<BtmsDecisionEntity>(this);
+        Comparisons = new MongoCollectionSet<ComparisonEntity>(this);
     }
 
     internal IMongoDatabase Database { get; }
@@ -27,6 +28,7 @@ public class MongoDbContext : IDbContext
 
     public IMongoCollectionSet<AlvsDecisionEntity> AlvsDecisions { get; }
     public IMongoCollectionSet<BtmsDecisionEntity> BtmsDecisions { get; }
+    public IMongoCollectionSet<ComparisonEntity> Comparisons { get; }
 
     public async Task SaveChangesAsync(CancellationToken cancellation = default)
     {
@@ -57,7 +59,7 @@ public class MongoDbContext : IDbContext
     private int GetChangedRecordsCount()
     {
         // This logic needs to be reviewed as it's easy to forget to include any new collection sets
-        return AlvsDecisions.PendingChanges + BtmsDecisions.PendingChanges;
+        return AlvsDecisions.PendingChanges + BtmsDecisions.PendingChanges + Comparisons.PendingChanges;
     }
 
     private async Task InternalSaveChangesAsync(CancellationToken cancellation = default)
@@ -65,5 +67,6 @@ public class MongoDbContext : IDbContext
         // This logic needs to be reviewed as it's easy to forget to include any new collection sets
         await AlvsDecisions.PersistAsync(cancellation);
         await BtmsDecisions.PersistAsync(cancellation);
+        await Comparisons.PersistAsync(cancellation);
     }
 }

--- a/src/Comparer/Domain/Comparison.cs
+++ b/src/Comparer/Domain/Comparison.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Serialization;
+
+namespace Defra.TradeImportsDecisionComparer.Comparer.Domain;
+
+public record Comparison(
+    [property: JsonPropertyName("created")] DateTime Created,
+    [property: JsonPropertyName("alvsXml")] string? AlvsXml,
+    [property: JsonPropertyName("btmsXml")] string? BtmsXml,
+    [property: JsonPropertyName("match")] bool Match,
+    [property: JsonPropertyName("reasons")] string[]? Reasons
+);

--- a/src/Comparer/Endpoints/Comparisons/EndpointRouteBuilderExtensions.cs
+++ b/src/Comparer/Endpoints/Comparisons/EndpointRouteBuilderExtensions.cs
@@ -1,0 +1,34 @@
+using System.Diagnostics.CodeAnalysis;
+using Defra.TradeImportsDecisionComparer.Comparer.Authentication;
+using Defra.TradeImportsDecisionComparer.Comparer.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Defra.TradeImportsDecisionComparer.Comparer.Endpoints.Comparisons;
+
+public static class EndpointRouteBuilderExtensions
+{
+    public static void MapComparisonEndpoints(this IEndpointRouteBuilder app, bool isDevelopment)
+    {
+        var route = app.MapGet("comparisons/{mrn}/", Get).RequireAuthorization(PolicyNames.Read);
+        AllowAnonymousForDevelopment(isDevelopment, route);
+    }
+
+    [ExcludeFromCodeCoverage]
+    private static void AllowAnonymousForDevelopment(bool isDevelopment, RouteHandlerBuilder route)
+    {
+        if (isDevelopment)
+            route.AllowAnonymous();
+    }
+
+    [HttpGet]
+    private static async Task<IResult> Get(
+        [FromRoute] string mrn,
+        [FromServices] IComparisonService comparisonService,
+        CancellationToken cancellationToken
+    )
+    {
+        var comparison = await comparisonService.Get(mrn, cancellationToken);
+
+        return Results.Ok(comparison);
+    }
+}

--- a/src/Comparer/Entities/AlvsDecisionEntity.cs
+++ b/src/Comparer/Entities/AlvsDecisionEntity.cs
@@ -1,4 +1,3 @@
-using System.Text.Json.Serialization;
 using Defra.TradeImportsDecisionComparer.Comparer.Data.Entities;
 using Defra.TradeImportsDecisionComparer.Comparer.Domain;
 

--- a/src/Comparer/Entities/ComparisonEntity.cs
+++ b/src/Comparer/Entities/ComparisonEntity.cs
@@ -1,0 +1,19 @@
+using Defra.TradeImportsDecisionComparer.Comparer.Data.Entities;
+using Defra.TradeImportsDecisionComparer.Comparer.Domain;
+
+namespace Defra.TradeImportsDecisionComparer.Comparer.Entities;
+
+public class ComparisonEntity : IDataEntity
+{
+    public required string Id { get; set; }
+
+    public string ETag { get; set; } = null!;
+
+    public DateTime Created { get; set; }
+
+    public DateTime Updated { get; set; }
+
+    public required List<Comparison> Comparisons { get; set; } = [];
+
+    public void OnSave() { }
+}

--- a/src/Comparer/Extensions/CdpCredentialsSqsClientProvider.cs
+++ b/src/Comparer/Extensions/CdpCredentialsSqsClientProvider.cs
@@ -1,0 +1,72 @@
+using Amazon;
+using Amazon.Runtime;
+using Amazon.SQS;
+using SlimMessageBus.Host.AmazonSQS;
+
+namespace Defra.TradeImportsDecisionComparer.Comparer.Extensions;
+
+public sealed class CdpCredentialsSqsClientProvider : ISqsClientProvider, IDisposable
+{
+    private const string DefaultRegion = "eu-west-2";
+    private bool _disposedValue;
+
+    public CdpCredentialsSqsClientProvider(AmazonSQSConfig sqsConfig, IConfiguration configuration)
+    {
+        var clientId = configuration.GetValue<string>("AWS_ACCESS_KEY_ID");
+        var clientSecret = configuration.GetValue<string>("AWS_SECRET_ACCESS_KEY");
+
+        if (!string.IsNullOrEmpty(clientSecret) && !string.IsNullOrEmpty(clientId))
+        {
+            var region = configuration.GetValue<string>("AWS_REGION") ?? DefaultRegion;
+            var regionEndpoint = RegionEndpoint.GetBySystemName(region);
+
+            Client = new AmazonSQSClient(
+                new BasicAWSCredentials(clientId, clientSecret),
+                new AmazonSQSConfig
+                {
+                    // https://github.com/aws/aws-sdk-net/issues/1781
+                    AuthenticationRegion = region,
+                    RegionEndpoint = regionEndpoint,
+                    ServiceURL = configuration.GetValue<string>("SQS_Endpoint"),
+                }
+            );
+
+            return;
+        }
+
+        Client = new AmazonSQSClient(sqsConfig);
+    }
+
+    #region ISqsClientProvider
+
+    public AmazonSQSClient Client { get; }
+
+    public Task EnsureClientAuthenticated()
+    {
+        return Task.CompletedTask;
+    }
+
+    #endregion
+
+    #region Dispose Pattern
+
+    private void Dispose(bool disposing)
+    {
+        if (_disposedValue)
+            return;
+
+        if (disposing)
+            Client?.Dispose();
+
+        _disposedValue = true;
+    }
+
+    public void Dispose()
+    {
+        // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    #endregion
+}

--- a/src/Comparer/Extensions/OptionsExtensions.cs
+++ b/src/Comparer/Extensions/OptionsExtensions.cs
@@ -1,0 +1,28 @@
+using Microsoft.Extensions.Options;
+
+namespace Defra.TradeImportsDecisionComparer.Comparer.Extensions;
+
+public static class OptionsExtensions
+{
+    public static OptionsBuilder<TOptions> AddValidateOptions<TOptions>(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        string section
+    )
+        where TOptions : class
+    {
+        return services.AddOptions<TOptions>().BindConfiguration(section).ValidateDataAnnotations();
+    }
+
+    public static TOptions Get<TOptions>(this OptionsBuilder<TOptions> optionsBuilder)
+        where TOptions : class
+    {
+        return optionsBuilder.Services.GetOptions<TOptions>();
+    }
+
+    private static TOptions GetOptions<TOptions>(this IServiceCollection services)
+        where TOptions : class
+    {
+        return services.BuildServiceProvider().GetRequiredService<IOptions<TOptions>>().Value;
+    }
+}

--- a/src/Comparer/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Comparer/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,55 @@
+using System.Text.Json;
+using Defra.TradeImportsDecisionComparer.Comparer.Configuration;
+using Defra.TradeImportsDecisionComparer.Comparer.Consumers;
+using Defra.TradeImportsDecisionComparer.Comparer.Utils.Logging;
+using SlimMessageBus.Host;
+using SlimMessageBus.Host.AmazonSQS;
+using SlimMessageBus.Host.Interceptor;
+using SlimMessageBus.Host.Serialization.SystemTextJson;
+
+namespace Defra.TradeImportsDecisionComparer.Comparer.Extensions;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddConsumers(this IServiceCollection services, IConfiguration configuration)
+    {
+        var options = services
+            .AddValidateOptions<FinalisationsConsumerOptions>(configuration, FinalisationsConsumerOptions.SectionName)
+            .Get();
+
+        if (!options.Enabled)
+            return services;
+
+        services.AddSlimMessageBus(smb =>
+        {
+            smb.AddChildBus(
+                "SQS_Finalisations",
+                mbb =>
+                {
+                    mbb.WithProviderAmazonSQS(cfg =>
+                    {
+                        cfg.TopologyProvisioning.Enabled = false;
+                        cfg.ClientProviderFactory = _ => new CdpCredentialsSqsClientProvider(
+                            cfg.SqsClientConfig,
+                            configuration
+                        );
+                    });
+                    mbb.AddJsonSerializer();
+
+                    mbb.AddServicesFromAssemblyContaining<FinalisationsConsumer>();
+                    mbb.Consume<JsonElement>(x => x.WithConsumer<FinalisationsConsumer>().Queue(options.QueueName));
+                }
+            );
+        });
+
+        return services;
+    }
+
+    public static IServiceCollection AddTracingForConsumers(this IServiceCollection services)
+    {
+        services.AddScoped(typeof(IConsumerInterceptor<>), typeof(TraceContextInterceptor<>));
+        services.AddSingleton(typeof(ISqsConsumerErrorHandler<>), typeof(SerilogTraceErrorHandler<>));
+
+        return services;
+    }
+}

--- a/src/Comparer/Program.cs
+++ b/src/Comparer/Program.cs
@@ -1,5 +1,6 @@
 using Defra.TradeImportsDecisionComparer.Comparer.Authentication;
 using Defra.TradeImportsDecisionComparer.Comparer.Data.Extensions;
+using Defra.TradeImportsDecisionComparer.Comparer.Endpoints.Comparisons;
 using Defra.TradeImportsDecisionComparer.Comparer.Endpoints.Decisions;
 using Defra.TradeImportsDecisionComparer.Comparer.Extensions;
 using Defra.TradeImportsDecisionComparer.Comparer.Health;
@@ -59,9 +60,10 @@ static void ConfigureWebApplication(WebApplicationBuilder builder, string[] args
     builder.Services.AddHttpClient();
     builder.Services.AddDbContext(builder.Configuration);
     builder.Services.AddAuthenticationAuthorization();
+    builder.Services.AddConsumers(builder.Configuration);
 
     builder.Services.AddTransient<IDecisionService, DecisionService>();
-    builder.Services.AddConsumers(builder.Configuration);
+    builder.Services.AddTransient<IComparisonService, ComparisonService>();
 }
 
 static WebApplication BuildWebApplication(WebApplicationBuilder builder)
@@ -74,6 +76,7 @@ static WebApplication BuildWebApplication(WebApplicationBuilder builder)
     app.UseAuthorization();
     app.MapHealth();
     app.MapDecisionEndpoints(isDevelopment);
+    app.MapComparisonEndpoints(isDevelopment);
     app.UseStatusCodePages();
     app.UseExceptionHandler(
         new ExceptionHandlerOptions

--- a/src/Comparer/Program.cs
+++ b/src/Comparer/Program.cs
@@ -1,6 +1,7 @@
 using Defra.TradeImportsDecisionComparer.Comparer.Authentication;
 using Defra.TradeImportsDecisionComparer.Comparer.Data.Extensions;
 using Defra.TradeImportsDecisionComparer.Comparer.Endpoints.Decisions;
+using Defra.TradeImportsDecisionComparer.Comparer.Extensions;
 using Defra.TradeImportsDecisionComparer.Comparer.Health;
 using Defra.TradeImportsDecisionComparer.Comparer.Services;
 using Defra.TradeImportsDecisionComparer.Comparer.Utils;
@@ -60,6 +61,7 @@ static void ConfigureWebApplication(WebApplicationBuilder builder, string[] args
     builder.Services.AddAuthenticationAuthorization();
 
     builder.Services.AddTransient<IDecisionService, DecisionService>();
+    builder.Services.AddConsumers(builder.Configuration);
 }
 
 static WebApplication BuildWebApplication(WebApplicationBuilder builder)

--- a/src/Comparer/Properties/launchSettings.json
+++ b/src/Comparer/Properties/launchSettings.json
@@ -7,7 +7,11 @@
       "applicationUrl": "http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
-        "ENVIRONMENT": "local"
+        "AWS_ACCESS_KEY_ID": "test",
+        "AWS_REGION": "eu-west-2",
+        "AWS_SECRET_ACCESS_KEY": "test",
+        "ENVIRONMENT": "local",
+        "SQS_ENDPOINT": "http://localhost:4566"
       }
     }
   }

--- a/src/Comparer/Services/ComparisonService.cs
+++ b/src/Comparer/Services/ComparisonService.cs
@@ -1,0 +1,20 @@
+using Defra.TradeImportsDecisionComparer.Comparer.Data;
+using Defra.TradeImportsDecisionComparer.Comparer.Entities;
+
+namespace Defra.TradeImportsDecisionComparer.Comparer.Services;
+
+public class ComparisonService(IDbContext dbContext) : IComparisonService
+{
+    public Task<ComparisonEntity?> Get(string mrn, CancellationToken cancellationToken) =>
+        dbContext.Comparisons.Find(mrn, cancellationToken);
+
+    public async Task Save(ComparisonEntity comparison, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(comparison.ETag))
+            await dbContext.Comparisons.Insert(comparison, cancellationToken);
+        else
+            await dbContext.Comparisons.Update(comparison, cancellationToken);
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/Comparer/Services/IComparisonService.cs
+++ b/src/Comparer/Services/IComparisonService.cs
@@ -1,0 +1,9 @@
+using Defra.TradeImportsDecisionComparer.Comparer.Entities;
+
+namespace Defra.TradeImportsDecisionComparer.Comparer.Services;
+
+public interface IComparisonService
+{
+    Task<ComparisonEntity?> Get(string mrn, CancellationToken cancellationToken);
+    Task Save(ComparisonEntity comparison, CancellationToken cancellationToken);
+}

--- a/src/Comparer/Utils/Logging/ITraceContext.cs
+++ b/src/Comparer/Utils/Logging/ITraceContext.cs
@@ -1,0 +1,6 @@
+namespace Defra.TradeImportsDecisionComparer.Comparer.Utils.Logging;
+
+public interface ITraceContext
+{
+    string? TraceId { get; }
+}

--- a/src/Comparer/Utils/Logging/ITraceContextAccessor.cs
+++ b/src/Comparer/Utils/Logging/ITraceContextAccessor.cs
@@ -1,0 +1,9 @@
+namespace Defra.TradeImportsDecisionComparer.Comparer.Utils.Logging;
+
+public interface ITraceContextAccessor
+{
+    /// <summary>
+    /// Gets or sets the current context.
+    /// </summary>
+    ITraceContext? Context { get; set; }
+}

--- a/src/Comparer/Utils/Logging/ReadOnlyDictionaryExtensions.cs
+++ b/src/Comparer/Utils/Logging/ReadOnlyDictionaryExtensions.cs
@@ -1,0 +1,9 @@
+namespace Defra.TradeImportsDecisionComparer.Comparer.Utils.Logging;
+
+public static class ReadOnlyDictionaryExtensions
+{
+    public static string? GetTraceId(this IReadOnlyDictionary<string, object> headers, string traceHeader)
+    {
+        return headers.TryGetValue(traceHeader, out var traceId) ? traceId.ToString()?.Replace("-", "") : null;
+    }
+}

--- a/src/Comparer/Utils/Logging/SerilogTraceErrorHandler.cs
+++ b/src/Comparer/Utils/Logging/SerilogTraceErrorHandler.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.Options;
+using Serilog.Context;
+using SlimMessageBus;
+using SlimMessageBus.Host;
+using SlimMessageBus.Host.AmazonSQS;
+
+namespace Defra.TradeImportsDecisionComparer.Comparer.Utils.Logging;
+
+public class SerilogTraceErrorHandler<TMessage>(
+    IOptions<TraceHeader> traceHeader,
+    ILogger<SerilogTraceErrorHandler<TMessage>> logger
+) : SqsConsumerErrorHandler<TMessage>
+{
+    public override Task<ProcessResult> OnHandleError(
+        TMessage message,
+        IConsumerContext consumerContext,
+        Exception exception,
+        int attempts
+    )
+    {
+        var traceId = consumerContext.Headers.GetTraceId(traceHeader.Value.Name);
+
+        using (LogContext.PushProperty(TraceContextEnricher.PropertyName, traceId))
+        {
+            // This ensures any trace header value is included with the exception, but it
+            // does mean the exception is logged twice - once here and once within SMB code.
+            logger.LogError(exception, "Error processing message");
+        }
+
+        return Task.FromResult(Failure());
+    }
+}

--- a/src/Comparer/Utils/Logging/TraceContext.cs
+++ b/src/Comparer/Utils/Logging/TraceContext.cs
@@ -1,0 +1,6 @@
+namespace Defra.TradeImportsDecisionComparer.Comparer.Utils.Logging;
+
+public class TraceContext : ITraceContext
+{
+    public string? TraceId { get; init; }
+}

--- a/src/Comparer/Utils/Logging/TraceContextAccessor.cs
+++ b/src/Comparer/Utils/Logging/TraceContextAccessor.cs
@@ -1,0 +1,29 @@
+namespace Defra.TradeImportsDecisionComparer.Comparer.Utils.Logging;
+
+/// <summary>
+/// Pattern taken from IHttpContextAccessor implementation.
+/// </summary>
+public class TraceContextAccessor : ITraceContextAccessor
+{
+    private static readonly AsyncLocal<ContextHolder> s_contextCurrent = new();
+
+    /// <inheritdoc/>
+    public ITraceContext? Context
+    {
+        get => s_contextCurrent.Value?.Context;
+        set
+        {
+            var holder = s_contextCurrent.Value;
+            if (holder != null)
+                holder.Context = null;
+
+            if (value != null)
+                s_contextCurrent.Value = new ContextHolder { Context = value };
+        }
+    }
+
+    private sealed class ContextHolder
+    {
+        public ITraceContext? Context;
+    }
+}

--- a/src/Comparer/Utils/Logging/TraceContextEnricher.cs
+++ b/src/Comparer/Utils/Logging/TraceContextEnricher.cs
@@ -1,0 +1,28 @@
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Defra.TradeImportsDecisionComparer.Comparer.Utils.Logging;
+
+public class TraceContextEnricher : ILogEventEnricher
+{
+    public const string PropertyName = "CorrelationId";
+    private readonly ITraceContextAccessor _traceContextAccessor;
+
+    public TraceContextEnricher()
+        : this(new TraceContextAccessor()) { }
+
+    private TraceContextEnricher(ITraceContextAccessor traceContextAccessor)
+    {
+        _traceContextAccessor = traceContextAccessor;
+    }
+
+    /// <inheritdoc/>
+    public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+    {
+        var requestContext = _traceContextAccessor.Context;
+        if (requestContext == null)
+            return;
+
+        logEvent.AddOrUpdateProperty(new LogEventProperty(PropertyName, new ScalarValue(requestContext.TraceId)));
+    }
+}

--- a/src/Comparer/Utils/Logging/TraceContextInterceptor.cs
+++ b/src/Comparer/Utils/Logging/TraceContextInterceptor.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.HeaderPropagation;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using SlimMessageBus;
+using SlimMessageBus.Host.Interceptor;
+
+namespace Defra.TradeImportsDecisionComparer.Comparer.Utils.Logging;
+
+public class TraceContextInterceptor<TMessage>(
+    IOptions<TraceHeader> traceHeader,
+    ITraceContextAccessor traceContextAccessor,
+    HeaderPropagationValues headerPropagationValues
+) : IConsumerInterceptor<TMessage>
+{
+    public async Task<object> OnHandle(TMessage message, Func<Task<object>> next, IConsumerContext context)
+    {
+        // Setting the trace context will take either the trace ID from the incoming
+        // message headers or it will start a new trace ID that may be propagated onwards
+        // to any nested HTTP calls or further message publishing
+        traceContextAccessor.Context = new TraceContext
+        {
+            TraceId = context.Headers.GetTraceId(traceHeader.Value.Name) ?? Guid.NewGuid().ToString("N"),
+        };
+
+        // As per the middleware implementation for header propagation, the following sets
+        // the headerPropagationValues.Headers value so it can be used by any configured
+        // HTTP handler
+        var headers = headerPropagationValues.Headers ??= new Dictionary<string, StringValues>(
+            StringComparer.OrdinalIgnoreCase
+        );
+
+        headers.Add(traceHeader.Value.Name, traceContextAccessor.Context.TraceId);
+
+        return await next();
+    }
+}

--- a/src/Comparer/Utils/Logging/WebApplicationBuilderExtensions.cs
+++ b/src/Comparer/Utils/Logging/WebApplicationBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using Defra.TradeImportsDecisionComparer.Comparer.Extensions;
 using Elastic.Serilog.Enrichers.Web;
 using Microsoft.AspNetCore.HeaderPropagation;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -13,11 +14,13 @@ public static class WebApplicationBuilderExtensions
     public static void ConfigureLoggingAndTracing(this WebApplicationBuilder builder, bool integrationTest = false)
     {
         builder.Services.AddHttpContextAccessor();
+        builder.Services.TryAddSingleton<ITraceContextAccessor, TraceContextAccessor>();
         builder
             .Services.AddOptions<TraceHeader>()
             .Bind(builder.Configuration)
             .ValidateDataAnnotations()
             .ValidateOnStart();
+        builder.Services.AddTracingForConsumers();
 
         // Replaces use of AddHeaderPropagation so we can configure outside startup
         // and use the TraceHeader options configured above that will have been validated
@@ -48,18 +51,15 @@ public static class WebApplicationBuilderExtensions
     )
     {
         var httpAccessor = services.GetRequiredService<IHttpContextAccessor>();
-        var traceIdHeader = hostBuilderContext.Configuration.GetValue<string>("TraceHeader");
         var serviceVersion = Environment.GetEnvironmentVariable("SERVICE_VERSION") ?? "";
 
         config
             .ReadFrom.Configuration(hostBuilderContext.Configuration)
             .Enrich.WithEcsHttpContext(httpAccessor)
             .Enrich.FromLogContext()
-            .Enrich.WithProperty("service.version", serviceVersion);
+            .Enrich.With(new TraceContextEnricher());
 
-        if (traceIdHeader != null)
-        {
-            config.Enrich.WithCorrelationId(traceIdHeader);
-        }
+        if (!string.IsNullOrWhiteSpace(serviceVersion))
+            config.Enrich.WithProperty("service.version", serviceVersion);
     }
 }

--- a/src/Comparer/Utils/Logging/WebApplicationBuilderExtensions.cs
+++ b/src/Comparer/Utils/Logging/WebApplicationBuilderExtensions.cs
@@ -51,13 +51,15 @@ public static class WebApplicationBuilderExtensions
     )
     {
         var httpAccessor = services.GetRequiredService<IHttpContextAccessor>();
+        var traceHeader = services.GetRequiredService<IOptions<TraceHeader>>().Value;
         var serviceVersion = Environment.GetEnvironmentVariable("SERVICE_VERSION") ?? "";
 
         config
             .ReadFrom.Configuration(hostBuilderContext.Configuration)
             .Enrich.WithEcsHttpContext(httpAccessor)
             .Enrich.FromLogContext()
-            .Enrich.With(new TraceContextEnricher());
+            .Enrich.With(new TraceContextEnricher())
+            .Enrich.WithCorrelationId(traceHeader.Name);
 
         if (!string.IsNullOrWhiteSpace(serviceVersion))
             config.Enrich.WithProperty("service.version", serviceVersion);

--- a/src/Comparer/appsettings.Development.json
+++ b/src/Comparer/appsettings.Development.json
@@ -17,7 +17,7 @@
       {
         "Name": "Console",
         "Args": {
-          "outputTemplate": "{Timestamp:o} [{Level:u4}] ({Application}/{MachineName}/{ThreadId}/{SourceContext}.{Method}) {Message}{NewLine}{Exception}"
+          "outputTemplate": "{Timestamp:o} [{Level:u4}] {Message} {Properties}{NewLine}{Exception}"
         }
       }
     ]

--- a/src/Comparer/appsettings.IntegrationTests.json
+++ b/src/Comparer/appsettings.IntegrationTests.json
@@ -25,5 +25,11 @@
         ]
       }
     }
+  },
+  "DataApi": {
+    "BaseAddress": "http://localhost:9090"
+  },
+  "FinalisationsConsumer": {
+    "Enabled": false
   }
 }

--- a/src/Comparer/appsettings.json
+++ b/src/Comparer/appsettings.json
@@ -36,6 +36,11 @@
           "read",
           "write"
         ]
+      },
+      "Developer": {
+        "Scopes": [
+          "read"
+        ]
       }
     }
   },

--- a/src/Comparer/appsettings.json
+++ b/src/Comparer/appsettings.json
@@ -38,5 +38,11 @@
         ]
       }
     }
+  },
+  "DataApi": {
+    "Username": "TradeImportsDecisionComparer"
+  },
+  "FinalisationsConsumer": {
+    "QueueName": "trade_imports_data_upserted_decision_comparer"
   }
 }

--- a/tests/Comparer.IntegrationTests/Comparer.IntegrationTests.csproj
+++ b/tests/Comparer.IntegrationTests/Comparer.IntegrationTests.csproj
@@ -20,6 +20,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="WireMock.Net.RestClient" Version="1.7.4" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="Xunit" />

--- a/tests/Comparer.IntegrationTests/Consumers/FinalisationsConsumerTests.cs
+++ b/tests/Comparer.IntegrationTests/Consumers/FinalisationsConsumerTests.cs
@@ -1,0 +1,17 @@
+using FluentAssertions;
+using Xunit.Abstractions;
+
+namespace Defra.TradeImportsDecisionComparer.Comparer.IntegrationTests.Consumers;
+
+[Collection(nameof(WireMockClientCollection))]
+public class FinalisationsConsumerTests(ITestOutputHelper output) : SqsTestBase(output)
+{
+    [Fact]
+    public async Task SendAndReceive()
+    {
+        await SendMessage("{\"json\": true}");
+        await ReceiveMessage();
+
+        true.Should().BeTrue();
+    }
+}

--- a/tests/Comparer.IntegrationTests/SqsTestBase.cs
+++ b/tests/Comparer.IntegrationTests/SqsTestBase.cs
@@ -1,0 +1,42 @@
+using Amazon.Runtime;
+using Amazon.SQS;
+using Amazon.SQS.Model;
+using Xunit.Abstractions;
+
+namespace Defra.TradeImportsDecisionComparer.Comparer.IntegrationTests;
+
+public class SqsTestBase(ITestOutputHelper output) : IntegrationTestBase
+{
+    private const string QueueUrl =
+        "http://sqs.eu-west-2.127.0.0.1:4566/000000000000/trade_imports_data_upserted_decision_comparer";
+
+    private readonly AmazonSQSClient _sqsClient = new(
+        new BasicAWSCredentials("test", "test"),
+        new AmazonSQSConfig { AuthenticationRegion = "eu-west-2", ServiceURL = "http://localhost:4566" }
+    );
+
+    protected Task<ReceiveMessageResponse> ReceiveMessage()
+    {
+        return _sqsClient.ReceiveMessageAsync(QueueUrl, CancellationToken.None);
+    }
+
+    protected Task<GetQueueAttributesResponse> GetQueueAttributes()
+    {
+        return _sqsClient.GetQueueAttributesAsync(
+            new GetQueueAttributesRequest { AttributeNames = ["ApproximateNumberOfMessages"], QueueUrl = QueueUrl },
+            CancellationToken.None
+        );
+    }
+
+    protected async Task SendMessage(string body, Dictionary<string, MessageAttributeValue>? messageAttributes = null)
+    {
+        var request = new SendMessageRequest
+        {
+            MessageAttributes = messageAttributes,
+            MessageBody = body,
+            QueueUrl = QueueUrl,
+        };
+        var result = await _sqsClient.SendMessageAsync(request, CancellationToken.None);
+        output.WriteLine("Sent {0} to {1}", result.MessageId, QueueUrl);
+    }
+}

--- a/tests/Comparer.IntegrationTests/WireMockClient.cs
+++ b/tests/Comparer.IntegrationTests/WireMockClient.cs
@@ -1,0 +1,18 @@
+using RestEase;
+using WireMock.Client;
+
+namespace Defra.TradeImportsDecisionComparer.Comparer.IntegrationTests;
+
+public class WireMockClient
+{
+    public WireMockClient()
+    {
+        WireMockAdminApi.ResetMappingsAsync().GetAwaiter().GetResult();
+        WireMockAdminApi.ResetRequestsAsync().GetAwaiter().GetResult();
+    }
+
+    public IWireMockAdminApi WireMockAdminApi { get; } = RestClient.For<IWireMockAdminApi>("http://localhost:9090");
+}
+
+[CollectionDefinition(nameof(WireMockClientCollection))]
+public class WireMockClientCollection : ICollectionFixture<WireMockClient>;


### PR DESCRIPTION
As per PR title.

The actual comparison does not exist yet, so it's always setting the comparison result to false.

The main aim of this PR is to get finalisation events consuming and then comparison data being populated. Saving the decisions is already in place and the gateway should be sending those soon, once deployed to DEV.