### PR TITLE
Add simple Parity endpoint 

### DIFF
--- a/src/Comparer/Endpoints/Parity/EndpointRouteBuilderExtensions.cs
+++ b/src/Comparer/Endpoints/Parity/EndpointRouteBuilderExtensions.cs
@@ -1,0 +1,35 @@
+using System.Diagnostics.CodeAnalysis;
+using Defra.TradeImportsDecisionComparer.Comparer.Authentication;
+using Defra.TradeImportsDecisionComparer.Comparer.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Defra.TradeImportsDecisionComparer.Comparer.Endpoints.Parity;
+
+public static class EndpointRouteBuilderExtensions
+{
+    public static void MapParityEndpoints(this IEndpointRouteBuilder app, bool isDevelopment)
+    {
+        var route = app.MapGet("parity", Get).RequireAuthorization(PolicyNames.Read);
+        AllowAnonymousForDevelopment(isDevelopment, route);
+    }
+
+    [ExcludeFromCodeCoverage]
+    private static void AllowAnonymousForDevelopment(bool isDevelopment, RouteHandlerBuilder route)
+    {
+        if (isDevelopment)
+            route.AllowAnonymous();
+    }
+
+    [HttpGet]
+    private static async Task<IResult> Get(
+        [FromQuery] DateTime? start,
+        [FromQuery] DateTime? end,
+        [FromServices] IParityService parityService,
+        CancellationToken cancellationToken
+    )
+    {
+        var comparison = await parityService.Get(start, end, cancellationToken);
+
+        return Results.Ok(comparison);
+    }
+}

--- a/src/Comparer/Entities/ComparisonEntity.cs
+++ b/src/Comparer/Entities/ComparisonEntity.cs
@@ -13,7 +13,9 @@ public class ComparisonEntity : IDataEntity
 
     public DateTime Updated { get; set; }
 
-    public required List<Comparison> Comparisons { get; set; } = [];
+    public required Comparison Latest { get; set; }
+
+    public List<Comparison> History { get; set; } = [];
 
     public void OnSave() { }
 }

--- a/src/Comparer/Program.cs
+++ b/src/Comparer/Program.cs
@@ -4,6 +4,7 @@ using Defra.TradeImportsDecisionComparer.Comparer.Data.Extensions;
 using Defra.TradeImportsDecisionComparer.Comparer.Endpoints.Comparisons;
 using Defra.TradeImportsDecisionComparer.Comparer.Endpoints.Decisions;
 using Defra.TradeImportsDecisionComparer.Comparer.Endpoints.OutboundErrors;
+using Defra.TradeImportsDecisionComparer.Comparer.Endpoints.Parity;
 using Defra.TradeImportsDecisionComparer.Comparer.Extensions;
 using Defra.TradeImportsDecisionComparer.Comparer.Health;
 using Defra.TradeImportsDecisionComparer.Comparer.Services;
@@ -69,6 +70,7 @@ static void ConfigureWebApplication(WebApplicationBuilder builder, string[] args
     builder.Services.AddAuthenticationAuthorization();
     builder.Services.AddConsumers(builder.Configuration);
 
+    builder.Services.AddTransient<IParityService, ParityService>();
     builder.Services.AddTransient<IOutboundErrorService, OutboundErrorService>();
     builder.Services.AddTransient<IDecisionService, DecisionService>();
     builder.Services.AddTransient<IComparisonService, ComparisonService>();
@@ -85,6 +87,7 @@ static WebApplication BuildWebApplication(WebApplicationBuilder builder)
     app.MapHealth();
     app.MapDecisionEndpoints(isDevelopment);
     app.MapOutboundErrorsEndpoints(isDevelopment);
+    app.MapParityEndpoints(isDevelopment);
     app.MapComparisonEndpoints(isDevelopment);
     app.UseStatusCodePages();
     app.UseExceptionHandler(

--- a/src/Comparer/Projections/ParityProjection.cs
+++ b/src/Comparer/Projections/ParityProjection.cs
@@ -1,0 +1,5 @@
+using Defra.TradeImportsDecisionComparer.Comparer.Comparision;
+
+namespace Defra.TradeImportsDecisionComparer.Comparer.Projections;
+
+public record ParityProjection(Dictionary<ComparisionOutcome, int> Stats, List<string> MisMatchMrns);

--- a/src/Comparer/Projections/ParityProjection.cs
+++ b/src/Comparer/Projections/ParityProjection.cs
@@ -2,4 +2,4 @@ using Defra.TradeImportsDecisionComparer.Comparer.Comparision;
 
 namespace Defra.TradeImportsDecisionComparer.Comparer.Projections;
 
-public record ParityProjection(Dictionary<ComparisionOutcome, int> Stats, List<string> MisMatchMrns);
+public record ParityProjection(Dictionary<string, int> Stats, List<string> MisMatchMrns);

--- a/src/Comparer/Services/IParityService.cs
+++ b/src/Comparer/Services/IParityService.cs
@@ -1,0 +1,10 @@
+using Defra.TradeImportsDecisionComparer.Comparer.Entities;
+using Defra.TradeImportsDecisionComparer.Comparer.Projections;
+using Polly;
+
+namespace Defra.TradeImportsDecisionComparer.Comparer.Services;
+
+public interface IParityService
+{
+    Task<ParityProjection> Get(DateTime? start, DateTime? end, CancellationToken cancellationToken);
+}

--- a/src/Comparer/Services/ParityService.cs
+++ b/src/Comparer/Services/ParityService.cs
@@ -25,8 +25,8 @@ public class ParityService(IDbContext dbContext) : IParityService
 
         var countQuery =
             from c in query
-            group c by c.Latest.Match into grp
-            select new KeyValuePair<ComparisionOutcome, int>(grp.Key, grp.Count());
+            group c by c.Latest.Match.ToString() into grp
+            select new KeyValuePair<string, int>(grp.Key, grp.Count());
 
         var misMatchMrnQuery = from c in query where c.Latest.Match == ComparisionOutcome.Mismatch select c.Id;
 

--- a/src/Comparer/Services/ParityService.cs
+++ b/src/Comparer/Services/ParityService.cs
@@ -1,0 +1,38 @@
+using System.Diagnostics.CodeAnalysis;
+using Defra.TradeImportsDecisionComparer.Comparer.Comparision;
+using Defra.TradeImportsDecisionComparer.Comparer.Data;
+using Defra.TradeImportsDecisionComparer.Comparer.Projections;
+using MongoDB.Driver.Linq;
+
+namespace Defra.TradeImportsDecisionComparer.Comparer.Services;
+
+[ExcludeFromCodeCoverage] // see integration tests
+public class ParityService(IDbContext dbContext) : IParityService
+{
+    public async Task<ParityProjection> Get(DateTime? start, DateTime? end, CancellationToken cancellationToken)
+    {
+        var query = from c in dbContext.Comparisons select c;
+
+        if (start.HasValue)
+        {
+            query = from c in query where c.Updated >= start select c;
+        }
+
+        if (end.HasValue)
+        {
+            query = from c in query where c.Updated <= end select c;
+        }
+
+        var countQuery =
+            from c in query
+            group c by c.Latest.Match into grp
+            select new KeyValuePair<ComparisionOutcome, int>(grp.Key, grp.Count());
+
+        var misMatchMrnQuery = from c in query where c.Latest.Match == ComparisionOutcome.Mismatch select c.Id;
+
+        return new ParityProjection(
+            new(await countQuery.ToListAsync(cancellationToken)),
+            await misMatchMrnQuery.ToListAsync(cancellationToken)
+        );
+    }
+}

--- a/tests/Comparer.IntegrationTests/Consumers/FinalisationsConsumerTests.cs
+++ b/tests/Comparer.IntegrationTests/Consumers/FinalisationsConsumerTests.cs
@@ -50,7 +50,7 @@ public class FinalisationsConsumerTests(ITestOutputHelper output) : SqsTestBase(
                     JsonSerializer.Deserialize<ComparisonEntity>(content, s_options)
                     ?? throw new Exception("Failed to deserialize");
 
-                return entity.Comparisons is [{ AlvsXml: null, BtmsXml: null }];
+                return entity.Latest is { AlvsXml: null, BtmsXml: null };
             })
         );
     }
@@ -97,7 +97,7 @@ public class FinalisationsConsumerTests(ITestOutputHelper output) : SqsTestBase(
                     JsonSerializer.Deserialize<ComparisonEntity>(content, s_options)
                     ?? throw new Exception("Failed to deserialize");
 
-                return entity.Comparisons is [{ AlvsXml: sampleDecision, BtmsXml: sampleDecision }];
+                return entity.Latest is { AlvsXml: sampleDecision, BtmsXml: sampleDecision };
             })
         );
 
@@ -131,11 +131,11 @@ public class FinalisationsConsumerTests(ITestOutputHelper output) : SqsTestBase(
                     JsonSerializer.Deserialize<ComparisonEntity>(content, s_options)
                     ?? throw new Exception("Failed to deserialize");
 
-                return entity.Comparisons
-                    is [
-                        { AlvsXml: sampleDecision, BtmsXml: sampleDecision },
-                        { AlvsXml: sampleDecision, BtmsXml: sampleDecision },
-                    ];
+                return entity
+                    is {
+                        History: [{ AlvsXml: sampleDecision, BtmsXml: sampleDecision }],
+                        Latest: { AlvsXml: sampleDecision, BtmsXml: sampleDecision }
+                    };
             })
         );
     }

--- a/tests/Comparer.IntegrationTests/Endpoints/ParityTests.cs
+++ b/tests/Comparer.IntegrationTests/Endpoints/ParityTests.cs
@@ -35,8 +35,8 @@ public class ParityTests(ITestOutputHelper output) : SqsTestBase(output)
         var result =
             JsonSerializer.Deserialize<ParityProjection>(content, s_options)
             ?? throw new Exception("Failed to deserialize");
-        result.MisMatchMrns.Should().BeEmpty();
-        result.Stats.Should().BeEmpty();
+        result.MisMatchMrns.Should().BeNullOrEmpty();
+        result.Stats.Should().BeNullOrEmpty();
     }
 
     [Fact]

--- a/tests/Comparer.IntegrationTests/Endpoints/ParityTests.cs
+++ b/tests/Comparer.IntegrationTests/Endpoints/ParityTests.cs
@@ -90,6 +90,6 @@ public class ParityTests(ITestOutputHelper output) : SqsTestBase(output)
         };
 
         await SendMessage(JsonSerializer.Serialize(message));
-        ///await WaitOnMessagesBeingProcessed();
+        await WaitOnMessagesBeingProcessed();
     }
 }

--- a/tests/Comparer.IntegrationTests/Endpoints/ParityTests.cs
+++ b/tests/Comparer.IntegrationTests/Endpoints/ParityTests.cs
@@ -42,6 +42,7 @@ public class ParityTests(ITestOutputHelper output) : SqsTestBase(output)
     public async Task WhenParityExists_ShouldReturnResults()
     {
         await DrainAllMessages();
+        ClearDatabase();
         var client = CreateClient();
 
         await InsertDecisionsForMrn("parity-mrn1", decision1, decision1);

--- a/tests/Comparer.IntegrationTests/Endpoints/ParityTests.cs
+++ b/tests/Comparer.IntegrationTests/Endpoints/ParityTests.cs
@@ -1,0 +1,94 @@
+using System.Net;
+using System.Text.Json;
+using Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
+using Defra.TradeImportsDataApi.Domain.Events;
+using Defra.TradeImportsDecisionComparer.Comparer.Projections;
+using FluentAssertions;
+using Xunit.Abstractions;
+
+namespace Defra.TradeImportsDecisionComparer.Comparer.IntegrationTests.Endpoints;
+
+public class ParityTests(ITestOutputHelper output) : SqsTestBase(output)
+{
+    private static readonly JsonSerializerOptions s_options = new() { PropertyNameCaseInsensitive = true };
+
+    private const string decision1 =
+        "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\">\r\n    <soap:Header>\r\n       <oas:Security soap:role=\"system\" soap:mustUnderstand=\"true\" xmlns:oas=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\">\r\n            <oas:UsernameToken>\r\n                <oas:Username>ibmtest</oas:Username>\r\n                <oas:Password>password</oas:Password>\r\n            </oas:UsernameToken>\r\n        </oas:Security>\r\n    </soap:Header>\r\n    <soap:Body>\r\n        <DecisionNotification xmlns=\"http://uk.gov.hmrc.ITSW2.ws\">\r\n            <DecisionNotification xmlns=\"http://www.hmrc.gov.uk/webservices/itsw/ws/decisionnotification\">\r\n                <ServiceHeader>\r\n                    <SourceSystem>ALVS</SourceSystem>\r\n                    <DestinationSystem>CDS</DestinationSystem>\r\n                    <CorrelationId>000</CorrelationId>\r\n                    <ServiceCallTimestamp>2023-06-30T07:34:14.405827</ServiceCallTimestamp>\r\n                </ServiceHeader>\r\n                <Header>\r\n                    <EntryReference>23GB1234567890ABC8</EntryReference>\r\n                    <EntryVersionNumber>1</EntryVersionNumber>\r\n                    <DecisionNumber>1</DecisionNumber>\r\n                </Header>\r\n                <Item>\r\n                    <ItemNumber>1</ItemNumber>\r\n                    <Check>\r\n                        <CheckCode>H218</CheckCode>\r\n                        <DecisionCode>X00</DecisionCode>\r\n                        <DecisionValidUntil>202307042359</DecisionValidUntil>\r\n                    </Check>                   \r\n                </Item>               \r\n            </DecisionNotification>\r\n        </DecisionNotification>\r\n    </soap:Body>\r\n</soap:Envelope>";
+
+    private const string decision2 =
+        "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\">\r\n    <soap:Header>\r\n       <oas:Security soap:role=\"system\" soap:mustUnderstand=\"true\" xmlns:oas=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\">\r\n            <oas:UsernameToken>\r\n                <oas:Username>ibmtest</oas:Username>\r\n                <oas:Password>password</oas:Password>\r\n            </oas:UsernameToken>\r\n        </oas:Security>\r\n    </soap:Header>\r\n    <soap:Body>\r\n        <DecisionNotification xmlns=\"http://uk.gov.hmrc.ITSW2.ws\">\r\n            <DecisionNotification xmlns=\"http://www.hmrc.gov.uk/webservices/itsw/ws/decisionnotification\">\r\n                <ServiceHeader>\r\n                    <SourceSystem>ALVS</SourceSystem>\r\n                    <DestinationSystem>CDS</DestinationSystem>\r\n                    <CorrelationId>000</CorrelationId>\r\n                    <ServiceCallTimestamp>2023-06-30T07:34:14.405827</ServiceCallTimestamp>\r\n                </ServiceHeader>\r\n                <Header>\r\n                    <EntryReference>23GB1234567890ABC8</EntryReference>\r\n                    <EntryVersionNumber>1</EntryVersionNumber>\r\n                    <DecisionNumber>1</DecisionNumber>\r\n                </Header>\r\n                <Item>\r\n                    <ItemNumber>1</ItemNumber>\r\n                    <Check>\r\n                        <CheckCode>H218</CheckCode>\r\n                        <DecisionCode>C02</DecisionCode>\r\n                        <DecisionValidUntil>202307042359</DecisionValidUntil>\r\n                    </Check>                   \r\n                </Item>               \r\n            </DecisionNotification>\r\n        </DecisionNotification>\r\n    </soap:Body>\r\n</soap:Envelope>";
+
+    private const string decision3 =
+        "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\">\r\n    <soap:Header>\r\n       <oas:Security soap:role=\"system\" soap:mustUnderstand=\"true\" xmlns:oas=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\">\r\n            <oas:UsernameToken>\r\n                <oas:Username>ibmtest</oas:Username>\r\n                <oas:Password>password</oas:Password>\r\n            </oas:UsernameToken>\r\n        </oas:Security>\r\n    </soap:Header>\r\n    <soap:Body>\r\n        <DecisionNotification xmlns=\"http://uk.gov.hmrc.ITSW2.ws\">\r\n            <DecisionNotification xmlns=\"http://www.hmrc.gov.uk/webservices/itsw/ws/decisionnotification\">\r\n                <ServiceHeader>\r\n                    <SourceSystem>ALVS</SourceSystem>\r\n                    <DestinationSystem>CDS</DestinationSystem>\r\n                    <CorrelationId>000</CorrelationId>\r\n                    <ServiceCallTimestamp>2023-06-30T07:34:14.405827</ServiceCallTimestamp>\r\n                </ServiceHeader>\r\n                <Header>\r\n                    <EntryReference>23GB1234567890ABC8</EntryReference>\r\n                    <EntryVersionNumber>1</EntryVersionNumber>\r\n                    <DecisionNumber>1</DecisionNumber>\r\n                </Header>\r\n                <Item>\r\n                    <ItemNumber>1</ItemNumber>\r\n                    <Check>\r\n                        <CheckCode>H218</CheckCode>\r\n                        <DecisionCode>C03</DecisionCode>\r\n                        <DecisionValidUntil>202307042359</DecisionValidUntil>\r\n                    </Check>                   \r\n                </Item>               \r\n            </DecisionNotification>\r\n        </DecisionNotification>\r\n    </soap:Body>\r\n</soap:Envelope>";
+
+    [Fact]
+    public async Task WhenNoComparisons_ShouldBeNullResults()
+    {
+        var client = CreateClient();
+        var mrn = Guid.NewGuid().ToString("N");
+
+        var response = await client.GetAsync(Testing.Endpoints.OutboundErrors.Get(mrn));
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsStringAsync();
+        var result =
+            JsonSerializer.Deserialize<ParityProjection>(content, s_options)
+            ?? throw new Exception("Failed to deserialize");
+        result.MisMatchMrns.Should().BeEmpty();
+        result.Stats.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task WhenParityExists_ShouldReturnResults()
+    {
+        await DrainAllMessages();
+        var client = CreateClient();
+
+        await InsertDecisionsForMrn("parity-mrn1", decision1, decision1);
+        await InsertDecisionsForMrn("parity-mrn2", decision2, decision3);
+        await InsertDecisionsForMrn("parity-mrn3", decision2, decision1);
+
+        var response = await client.GetAsync(Testing.Endpoints.Parity.Get(null, null));
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsStringAsync();
+        var result =
+            JsonSerializer.Deserialize<ParityProjection>(content, s_options)
+            ?? throw new Exception("Failed to deserialize");
+        result.MisMatchMrns.Count.Should().Be(1);
+        result.MisMatchMrns[0].Should().Be("parity-mrn3");
+        result.Stats.Count.Should().Be(3);
+        result.Stats["ExactMatch"].Should().Be(1);
+        result.Stats["Mismatch"].Should().Be(1);
+        result.Stats["GroupMatch"].Should().Be(1);
+    }
+
+    private async Task InsertDecisionsForMrn(string mrn, string alvsDecisionXml, string btmsDecisionXml)
+    {
+        ////var client = CreateClient();
+
+        ////var response = await client.PutAsync(
+        ////    Testing.Endpoints.Decisions.Alvs.Put(mrn),
+        ////    new StringContent(alvsDecisionXml, Encoding.UTF8, "application/xml")
+        ////);
+        ////response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        ////response = await client.PutAsync(
+        ////    Testing.Endpoints.Decisions.Btms.Put(mrn),
+        ////    new StringContent(btmsDecisionXml, Encoding.UTF8, "application/xml")
+        ////);
+        ////response.StatusCode.Should().Be(HttpStatusCode.OK);
+        Console.Write(alvsDecisionXml);
+        Console.Write(btmsDecisionXml);
+        var message = new ResourceEvent<CustomsDeclaration>
+        {
+            ResourceId = mrn,
+            ResourceType = "CustomsDeclaration",
+            SubResourceType = "Finalisation",
+            Operation = "Update",
+        };
+
+        await SendMessage(JsonSerializer.Serialize(message));
+        ///await WaitOnMessagesBeingProcessed();
+    }
+}

--- a/tests/Comparer.IntegrationTests/Endpoints/ParityTests.cs
+++ b/tests/Comparer.IntegrationTests/Endpoints/ParityTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Text;
 using System.Text.Json;
 using Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
 using Defra.TradeImportsDataApi.Domain.Events;
@@ -65,19 +66,19 @@ public class ParityTests(ITestOutputHelper output) : SqsTestBase(output)
 
     private async Task InsertDecisionsForMrn(string mrn, string alvsDecisionXml, string btmsDecisionXml)
     {
-        ////var client = CreateClient();
+        var client = CreateClient();
 
-        ////var response = await client.PutAsync(
-        ////    Testing.Endpoints.Decisions.Alvs.Put(mrn),
-        ////    new StringContent(alvsDecisionXml, Encoding.UTF8, "application/xml")
-        ////);
-        ////response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var response = await client.PutAsync(
+            Testing.Endpoints.Decisions.Alvs.Put(mrn),
+            new StringContent(alvsDecisionXml, Encoding.UTF8, "application/xml")
+        );
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        ////response = await client.PutAsync(
-        ////    Testing.Endpoints.Decisions.Btms.Put(mrn),
-        ////    new StringContent(btmsDecisionXml, Encoding.UTF8, "application/xml")
-        ////);
-        ////response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response = await client.PutAsync(
+            Testing.Endpoints.Decisions.Btms.Put(mrn),
+            new StringContent(btmsDecisionXml, Encoding.UTF8, "application/xml")
+        );
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         Console.Write(alvsDecisionXml);
         Console.Write(btmsDecisionXml);
         var message = new ResourceEvent<CustomsDeclaration>

--- a/tests/Comparer.IntegrationTests/Endpoints/ParityTests.cs
+++ b/tests/Comparer.IntegrationTests/Endpoints/ParityTests.cs
@@ -42,14 +42,13 @@ public class ParityTests(ITestOutputHelper output) : SqsTestBase(output)
     public async Task WhenParityExists_ShouldReturnResults()
     {
         await DrainAllMessages();
-        ClearDatabase();
         var client = CreateClient();
-
+        var start = DateTime.UtcNow;
         await InsertDecisionsForMrn("parity-mrn1", decision1, decision1);
         await InsertDecisionsForMrn("parity-mrn2", decision2, decision3);
         await InsertDecisionsForMrn("parity-mrn3", decision2, decision1);
 
-        var response = await client.GetAsync(Testing.Endpoints.Parity.Get(null, null));
+        var response = await client.GetAsync(Testing.Endpoints.Parity.Get(start, null));
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var content = await response.Content.ReadAsStringAsync();

--- a/tests/Comparer.IntegrationTests/IntegrationTestBase.cs
+++ b/tests/Comparer.IntegrationTests/IntegrationTestBase.cs
@@ -1,7 +1,3 @@
-using Defra.TradeImportsDecisionComparer.Comparer.Entities;
-using MongoDB.Bson;
-using MongoDB.Driver;
-
 namespace Defra.TradeImportsDecisionComparer.Comparer.IntegrationTests;
 
 [Trait("Category", "IntegrationTest")]
@@ -9,21 +5,4 @@ namespace Defra.TradeImportsDecisionComparer.Comparer.IntegrationTests;
 public abstract class IntegrationTestBase
 {
     protected static HttpClient CreateClient() => new() { BaseAddress = new Uri("http://localhost:8080") };
-
-    protected static IMongoDatabase CreateMongoDatabase() =>
-        new MongoClient("mongodb://host.docker.internal:27017?directConnection=true").GetDatabase(
-            "trade-imports-decision-comparer"
-        );
-
-    protected static void ClearDatabase()
-    {
-        var db = CreateMongoDatabase();
-        db.GetCollection<BsonDocument>(nameof(ComparisonEntity)).DeleteMany(FilterDefinition<BsonDocument>.Empty);
-        db.GetCollection<BsonDocument>(nameof(BtmsOutboundErrorEntity))
-            .DeleteMany(FilterDefinition<BsonDocument>.Empty);
-        db.GetCollection<BsonDocument>(nameof(AlvsOutboundErrorEntity))
-            .DeleteMany(FilterDefinition<BsonDocument>.Empty);
-        db.GetCollection<BsonDocument>(nameof(BtmsDecisionEntity)).DeleteMany(FilterDefinition<BsonDocument>.Empty);
-        db.GetCollection<BsonDocument>(nameof(AlvsDecisionEntity)).DeleteMany(FilterDefinition<BsonDocument>.Empty);
-    }
 }

--- a/tests/Comparer.IntegrationTests/IntegrationTestBase.cs
+++ b/tests/Comparer.IntegrationTests/IntegrationTestBase.cs
@@ -11,7 +11,7 @@ public abstract class IntegrationTestBase
     protected static HttpClient CreateClient() => new() { BaseAddress = new Uri("http://localhost:8080") };
 
     protected static IMongoDatabase CreateMongoDatabase() =>
-        new MongoClient("mongodb://127.0.0.1:27017").GetDatabase("trade-imports-decision-comparer");
+        new MongoClient("mongodb://host.docker.internal:27017?directConnection=true").GetDatabase("trade-imports-decision-comparer");
 
     protected static void ClearDatabase()
     {

--- a/tests/Comparer.IntegrationTests/IntegrationTestBase.cs
+++ b/tests/Comparer.IntegrationTests/IntegrationTestBase.cs
@@ -11,7 +11,9 @@ public abstract class IntegrationTestBase
     protected static HttpClient CreateClient() => new() { BaseAddress = new Uri("http://localhost:8080") };
 
     protected static IMongoDatabase CreateMongoDatabase() =>
-        new MongoClient("mongodb://host.docker.internal:27017?directConnection=true").GetDatabase("trade-imports-decision-comparer");
+        new MongoClient("mongodb://host.docker.internal:27017?directConnection=true").GetDatabase(
+            "trade-imports-decision-comparer"
+        );
 
     protected static void ClearDatabase()
     {

--- a/tests/Comparer.IntegrationTests/IntegrationTestBase.cs
+++ b/tests/Comparer.IntegrationTests/IntegrationTestBase.cs
@@ -1,3 +1,7 @@
+using Defra.TradeImportsDecisionComparer.Comparer.Entities;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
 namespace Defra.TradeImportsDecisionComparer.Comparer.IntegrationTests;
 
 [Trait("Category", "IntegrationTest")]
@@ -5,4 +9,19 @@ namespace Defra.TradeImportsDecisionComparer.Comparer.IntegrationTests;
 public abstract class IntegrationTestBase
 {
     protected static HttpClient CreateClient() => new() { BaseAddress = new Uri("http://localhost:8080") };
+
+    protected static IMongoDatabase CreateMongoDatabase() =>
+        new MongoClient("mongodb://127.0.0.1:27017").GetDatabase("trade-imports-decision-comparer");
+
+    protected static void ClearDatabase()
+    {
+        var db = CreateMongoDatabase();
+        db.GetCollection<BsonDocument>(nameof(ComparisonEntity)).DeleteMany(FilterDefinition<BsonDocument>.Empty);
+        db.GetCollection<BsonDocument>(nameof(BtmsOutboundErrorEntity))
+            .DeleteMany(FilterDefinition<BsonDocument>.Empty);
+        db.GetCollection<BsonDocument>(nameof(AlvsOutboundErrorEntity))
+            .DeleteMany(FilterDefinition<BsonDocument>.Empty);
+        db.GetCollection<BsonDocument>(nameof(BtmsDecisionEntity)).DeleteMany(FilterDefinition<BsonDocument>.Empty);
+        db.GetCollection<BsonDocument>(nameof(AlvsDecisionEntity)).DeleteMany(FilterDefinition<BsonDocument>.Empty);
+    }
 }

--- a/tests/Comparer.IntegrationTests/SqsTestBase.cs
+++ b/tests/Comparer.IntegrationTests/SqsTestBase.cs
@@ -39,6 +39,11 @@ public class SqsTestBase(ITestOutputHelper output) : IntegrationTestBase
         );
     }
 
+    protected async Task WaitOnMessagesBeingProcessed()
+    {
+        await AsyncWaiter.WaitForAsync(async () => (await GetQueueAttributes()).ApproximateNumberOfMessages == 0);
+    }
+
     protected async Task SendMessage(string body, Dictionary<string, MessageAttributeValue>? messageAttributes = null)
     {
         var request = new SendMessageRequest

--- a/tests/Comparer.Tests/Endpoints/Comparisons/GetTests.Get_WhenAuthorized_ShouldBeOk.verified.json
+++ b/tests/Comparer.Tests/Endpoints/Comparisons/GetTests.Get_WhenAuthorized_ShouldBeOk.verified.json
@@ -3,16 +3,15 @@
   "eTag": null,
   "created": "2025-04-23T08:30:00Z",
   "updated": "2025-04-23T08:30:00Z",
-  "comparisons": [
-    {
-      "created": "2025-04-23T08:30:00Z",
-      "alvsXml": "<xml alvs=\"true\"/>",
-      "btmsXml": "<xml btms=\"true\"/>",
-      "match": "ExactMatch",
-      "reasons": [
-        "Reason 1",
-        "Reason 2"
-      ]
-    }
-  ]
+  "latest": {
+    "created": "2025-04-23T08:30:00Z",
+    "alvsXml": "<xml alvs=\"true\"/>",
+    "btmsXml": "<xml btms=\"true\"/>",
+    "match": "ExactMatch",
+    "reasons": [
+      "Reason 1",
+      "Reason 2"
+    ]
+  },
+  "history": []
 }

--- a/tests/Comparer.Tests/Endpoints/Parity/GetTests.Get_WhenAuthorized_ShouldBeOk.verified.json
+++ b/tests/Comparer.Tests/Endpoints/Parity/GetTests.Get_WhenAuthorized_ShouldBeOk.verified.json
@@ -1,0 +1,8 @@
+﻿{
+  "stats": {
+    "Mismatch": 3
+  },
+  "misMatchMrns": [
+    "mrn"
+  ]
+}

--- a/tests/Comparer.Tests/Endpoints/Parity/GetTests.cs
+++ b/tests/Comparer.Tests/Endpoints/Parity/GetTests.cs
@@ -2,24 +2,25 @@ using System.Net;
 using Defra.TradeImportsDecisionComparer.Comparer.Comparision;
 using Defra.TradeImportsDecisionComparer.Comparer.Domain;
 using Defra.TradeImportsDecisionComparer.Comparer.Entities;
+using Defra.TradeImportsDecisionComparer.Comparer.Projections;
 using Defra.TradeImportsDecisionComparer.Comparer.Services;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using Xunit.Abstractions;
 
-namespace Defra.TradeImportsDecisionComparer.Comparer.Tests.Endpoints.Comparisons;
+namespace Defra.TradeImportsDecisionComparer.Comparer.Tests.Endpoints.Parity;
 
 public class GetTests(ComparerWebApplicationFactory factory, ITestOutputHelper outputHelper)
     : EndpointTestBase(factory, outputHelper)
 {
     private const string Mrn = "mrn";
-    private IComparisonService MockComparerService { get; } = Substitute.For<IComparisonService>();
+    private IParityService MockParityService { get; } = Substitute.For<IParityService>();
 
     protected override void ConfigureTestServices(IServiceCollection services)
     {
         base.ConfigureTestServices(services);
 
-        services.AddTransient<IComparisonService>(_ => MockComparerService);
+        services.AddTransient<IParityService>(_ => MockParityService);
     }
 
     [Fact]
@@ -27,7 +28,7 @@ public class GetTests(ComparerWebApplicationFactory factory, ITestOutputHelper o
     {
         var client = CreateClient(addDefaultAuthorizationHeader: false);
 
-        var response = await client.GetAsync(Testing.Endpoints.Comparisons.Get(Mrn));
+        var response = await client.GetAsync(Testing.Endpoints.Parity.Get(null, null));
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
@@ -37,7 +38,7 @@ public class GetTests(ComparerWebApplicationFactory factory, ITestOutputHelper o
     {
         var client = CreateClient(testUser: TestUser.WriteOnly);
 
-        var response = await client.GetAsync(Testing.Endpoints.Comparisons.Get(Mrn));
+        var response = await client.GetAsync(Testing.Endpoints.Parity.Get(null, null));
 
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
     }
@@ -46,25 +47,16 @@ public class GetTests(ComparerWebApplicationFactory factory, ITestOutputHelper o
     public async Task Get_WhenAuthorized_ShouldBeOk()
     {
         var client = CreateClient();
-        MockComparerService
-            .Get(Mrn, Arg.Any<CancellationToken>())
+        MockParityService
+            .Get(null, null, Arg.Any<CancellationToken>())
             .Returns(
-                new ComparisonEntity
-                {
-                    Id = Mrn,
-                    Created = new DateTime(2025, 4, 23, 8, 30, 0, DateTimeKind.Utc),
-                    Updated = new DateTime(2025, 4, 23, 8, 30, 0, DateTimeKind.Utc),
-                    Latest = new Comparison(
-                        new DateTime(2025, 4, 23, 8, 30, 0, DateTimeKind.Utc),
-                        "<xml alvs=\"true\"/>",
-                        "<xml btms=\"true\"/>",
-                        ComparisionOutcome.ExactMatch,
-                        ["Reason 1", "Reason 2"]
-                    ),
-                }
+                new ParityProjection(
+                    new Dictionary<ComparisionOutcome, int>() { { ComparisionOutcome.Mismatch, 3 } },
+                    [Mrn]
+                )
             );
 
-        var response = await client.GetAsync(Testing.Endpoints.Comparisons.Get(Mrn));
+        var response = await client.GetAsync(Testing.Endpoints.Parity.Get(null, null));
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 

--- a/tests/Comparer.Tests/Endpoints/Parity/GetTests.cs
+++ b/tests/Comparer.Tests/Endpoints/Parity/GetTests.cs
@@ -51,7 +51,7 @@ public class GetTests(ComparerWebApplicationFactory factory, ITestOutputHelper o
             .Get(null, null, Arg.Any<CancellationToken>())
             .Returns(
                 new ParityProjection(
-                    new Dictionary<ComparisionOutcome, int>() { { ComparisionOutcome.Mismatch, 3 } },
+                    new Dictionary<string, int>() { { nameof(ComparisionOutcome.Mismatch), 3 } },
                     [Mrn]
                 )
             );

--- a/tests/Testing/Endpoints.cs
+++ b/tests/Testing/Endpoints.cs
@@ -1,3 +1,6 @@
+using System.Globalization;
+using Microsoft.AspNetCore.Http;
+
 namespace Defra.TradeImportsDecisionComparer.Testing;
 
 public static class Endpoints
@@ -49,5 +52,27 @@ public static class Endpoints
         private static string Root => "/comparisons";
 
         public static string Get(string mrn) => $"{Root}/{mrn}";
+    }
+
+    public static class Parity
+    {
+        private static string Root => "/parity";
+
+        public static string Get(DateTime? start, DateTime? end)
+        {
+            var queryString = QueryString.Empty;
+
+            if (start.HasValue)
+            {
+                queryString.Add(nameof(start), start.Value.ToString(CultureInfo.InvariantCulture));
+            }
+
+            if (end.HasValue)
+            {
+                queryString.Add(nameof(end), end.Value.ToString(CultureInfo.InvariantCulture));
+            }
+
+            return $"{Root}?{queryString.Value}";
+        }
     }
 }


### PR DESCRIPTION
Added a simple parity endpoint which returns the count of comparisons grouped by outcome.

It also returns a list of MRNs for the Mismatch group to allow for investigation

Refactored the ComparisionEntity to store the Latest comparison separately.

The PR adds a backdoor for the integration tests to be able to clear the database.  This was required due to the Parity tests which runs a query over everything in the DB, and depending on what other tests do, the DB is left in an unknow state.