### PR TITLE
Set default consumers per host of 20

### DIFF
--- a/src/Comparer/Configuration/FinalisationsConsumerOptions.cs
+++ b/src/Comparer/Configuration/FinalisationsConsumerOptions.cs
@@ -12,4 +12,6 @@ public class FinalisationsConsumerOptions
     // This is only turned off in appsettings.IntegrationTests.json currently
     // as we don't want the consumers running for in memory integration tests.
     public required bool Enabled { get; init; } = true;
+
+    public int ConsumersPerHost { get; init; } = 20;
 }

--- a/src/Comparer/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Comparer/Extensions/ServiceCollectionExtensions.cs
@@ -37,7 +37,11 @@ public static class ServiceCollectionExtensions
                     mbb.AddJsonSerializer();
 
                     mbb.AddServicesFromAssemblyContaining<FinalisationsConsumer>();
-                    mbb.Consume<JsonElement>(x => x.WithConsumer<FinalisationsConsumer>().Queue(options.QueueName));
+                    mbb.Consume<JsonElement>(x =>
+                        x.WithConsumer<FinalisationsConsumer>()
+                            .Queue(options.QueueName)
+                            .Instances(options.ConsumersPerHost)
+                    );
                 }
             );
         });


### PR DESCRIPTION
The comparer will start with 3 hosts and 20 consumers per host, therefore 60 in total.