### PR TITLE
Added additional comparison outcomes

### DIFF
--- a/src/Comparer/Comparision/ComparisionOutcome.cs
+++ b/src/Comparer/Comparision/ComparisionOutcome.cs
@@ -7,6 +7,8 @@ public enum ComparisionOutcome
     ExactMatch = 1,
     GroupMatch = 2,
     Mismatch = 3,
+    NoAlvsDecision = 4,
+    NoBtmsDecision = 5,
 }
 
 public record ComparisionOutcomeEvaluatorContext(List<Item> AlvsItems, List<Item> BtmsItems);
@@ -15,6 +17,16 @@ public static class ComparisionOutcomeEvaluator
 {
     public static ComparisionOutcome GetComparisionOutcome(this ComparisionOutcomeEvaluatorContext context)
     {
+        if (!context.BtmsItems.Any())
+        {
+            return ComparisionOutcome.NoBtmsDecision;
+        }
+
+        if (!context.AlvsItems.Any())
+        {
+            return ComparisionOutcome.NoAlvsDecision;
+        }
+
         return context.BtmsItems.Compare(context.AlvsItems);
     }
 }

--- a/src/Comparer/Comparision/ComparisionOutcome.cs
+++ b/src/Comparer/Comparision/ComparisionOutcome.cs
@@ -17,12 +17,12 @@ public static class ComparisionOutcomeEvaluator
 {
     public static ComparisionOutcome GetComparisionOutcome(this ComparisionOutcomeEvaluatorContext context)
     {
-        if (!context.BtmsItems.Any())
+        if (context.BtmsItems.Count == 0)
         {
             return ComparisionOutcome.NoBtmsDecision;
         }
 
-        if (!context.AlvsItems.Any())
+        if (context.AlvsItems.Count == 0)
         {
             return ComparisionOutcome.NoAlvsDecision;
         }

--- a/tests/Comparer.Tests/Comparision/ComparisonTests.cs
+++ b/tests/Comparer.Tests/Comparision/ComparisonTests.cs
@@ -15,4 +15,20 @@ public class ComparisonTests
 
         result.Match.Should().Be(ComparisionOutcome.ExactMatch);
     }
+
+    [Fact]
+    public void WhenNoBtmsDecisionThenShouldReturnNoBtmsDecision()
+    {
+        var result = Comparison.Create(sampleDecision, null);
+
+        result.Match.Should().Be(ComparisionOutcome.NoBtmsDecision);
+    }
+
+    [Fact]
+    public void WhenNoAlvsDecisionThenShouldReturnNoAlvsDecision()
+    {
+        var result = Comparison.Create(null, sampleDecision);
+
+        result.Match.Should().Be(ComparisionOutcome.NoAlvsDecision);
+    }
 }


### PR DESCRIPTION
Added NoAlvsDecision and NoBtmsDecision outcomes

This query can be run on the DB to update the outcomes

`db.getCollection("Comparison").updateMany({ "latest.alvsXml" : null },  { $set: { "latest.match": "NoAlvsDecision" } })`

`db.getCollection("Comparison").updateMany({ "latest.btmsXml" : null },  { $set: { "latest.match": "NoBtmsDecision" } })`