### PR TITLE
Return 409 Conflict on concurrency exception

### DIFF
--- a/src/Comparer/Endpoints/Decisions/EndpointRouteBuilderExtensions.cs
+++ b/src/Comparer/Endpoints/Decisions/EndpointRouteBuilderExtensions.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Defra.TradeImportsDecisionComparer.Comparer.Authentication;
+using Defra.TradeImportsDecisionComparer.Comparer.Data;
 using Defra.TradeImportsDecisionComparer.Comparer.Domain;
 using Defra.TradeImportsDecisionComparer.Comparer.Services;
 using Microsoft.AspNetCore.Mvc;
@@ -69,7 +70,14 @@ public static class EndpointRouteBuilderExtensions
         using var reader = new StreamReader(context.Request.Body, leaveOpen: true);
         var xml = await reader.ReadToEndAsync(cancellationToken);
 
-        await save(new Decision(DateTime.UtcNow, xml), cancellationToken);
+        try
+        {
+            await save(new Decision(DateTime.UtcNow, xml), cancellationToken);
+        }
+        catch (ConcurrencyException)
+        {
+            return Results.Conflict();
+        }
 
         return Results.Content(xml, "application/xml", Encoding.UTF8);
     }

--- a/src/Comparer/Endpoints/OutboundErrors/EndpointRouteBuilderExtensions.cs
+++ b/src/Comparer/Endpoints/OutboundErrors/EndpointRouteBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Defra.TradeImportsDecisionComparer.Comparer.Authentication;
+using Defra.TradeImportsDecisionComparer.Comparer.Data;
 using Defra.TradeImportsDecisionComparer.Comparer.Domain;
 using Defra.TradeImportsDecisionComparer.Comparer.Services;
 using Microsoft.AspNetCore.Mvc;
@@ -78,7 +79,14 @@ public static class EndpointRouteBuilderExtensions
         using var reader = new StreamReader(context.Request.Body, leaveOpen: true);
         var xml = await reader.ReadToEndAsync(cancellationToken);
 
-        await save(new OutboundError(DateTime.UtcNow, xml), cancellationToken);
+        try
+        {
+            await save(new OutboundError(DateTime.UtcNow, xml), cancellationToken);
+        }
+        catch (ConcurrencyException)
+        {
+            return Results.Conflict();
+        }
 
         return Results.Ok();
     }

--- a/tests/Comparer.Tests/Endpoints/Decisions/PutTests.cs
+++ b/tests/Comparer.Tests/Endpoints/Decisions/PutTests.cs
@@ -1,7 +1,10 @@
 using System.Net;
+using Defra.TradeImportsDecisionComparer.Comparer.Data;
+using Defra.TradeImportsDecisionComparer.Comparer.Domain;
 using Defra.TradeImportsDecisionComparer.Comparer.Services;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit.Abstractions;
 
 namespace Defra.TradeImportsDecisionComparer.Comparer.Tests.Endpoints.Decisions;
@@ -56,6 +59,22 @@ public class PutTests(ComparerWebApplicationFactory factory, ITestOutputHelper o
     }
 
     [Fact]
+    public async Task PutAlvs_WhenConcurrencyException_ShouldBeConflict()
+    {
+        var client = CreateClient();
+        MockDecisionService
+            .AppendAlvsDecision(Mrn, Arg.Any<Decision>(), Arg.Any<CancellationToken>())
+            .Throws(new ConcurrencyException(Mrn, "etag"));
+
+        var response = await client.PutAsync(
+            Testing.Endpoints.Decisions.Alvs.Put(Mrn),
+            new StringContent("<xml alvs=\"true\" />")
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Fact]
     public async Task PutBtms_WhenUnauthorized_ShouldBeUnauthorized()
     {
         var client = CreateClient(addDefaultAuthorizationHeader: false);
@@ -89,5 +108,21 @@ public class PutTests(ComparerWebApplicationFactory factory, ITestOutputHelper o
         var content = await response.Content.ReadAsStringAsync();
 
         await Verify(content);
+    }
+
+    [Fact]
+    public async Task PutBtms_WhenConcurrencyException_ShouldBeConflict()
+    {
+        var client = CreateClient();
+        MockDecisionService
+            .AppendBtmsDecision(Mrn, Arg.Any<Decision>(), Arg.Any<CancellationToken>())
+            .Throws(new ConcurrencyException(Mrn, "etag"));
+
+        var response = await client.PutAsync(
+            Testing.Endpoints.Decisions.Btms.Put(Mrn),
+            new StringContent("<xml btms=\"true\" />")
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
     }
 }


### PR DESCRIPTION
As per PR title.

We observed during message replay, two outbound error resource events for the same MRN be processed by the gateway and saved in the comparer. One failed with a 500 as the other wrote first. The gateway then retried and wrote OK.

We want to improve the clarity of the comparer write endpoint so it returns a 409 Conflict for a concurrency exception rather than an unhandled 500.