### PR TITLE
CDMS-851: temporary test build to facilitate testing in Dev

### DIFF
--- a/src/Comparer/Endpoints/Decisions/EndpointRouteBuilderExtensions.cs
+++ b/src/Comparer/Endpoints/Decisions/EndpointRouteBuilderExtensions.cs
@@ -59,6 +59,8 @@ public static class EndpointRouteBuilderExtensions
     }
 
     [SuppressMessage("SonarLint", "S5131", Justification = "This service cannot be compromised by a malicious user")]
+    [SuppressMessage("SonarLint", "S1481", Justification = "Just testing for now")]
+    [SuppressMessage("SonarLint", "S125", Justification = "Just testing for now")]
     private static async Task<IResult> ReadAndSave(
         HttpContext context,
         Func<Decision, CancellationToken, Task> save,
@@ -72,13 +74,13 @@ public static class EndpointRouteBuilderExtensions
 
         try
         {
-            await save(new Decision(DateTime.UtcNow, xml), cancellationToken);
+            // await save(new Decision(DateTime.UtcNow, xml), cancellationToken);
         }
         catch (ConcurrencyException)
         {
             return Results.Conflict();
         }
 
-        return Results.Content(xml, "application/xml", Encoding.UTF8);
+        return Results.Conflict();
     }
 }

--- a/src/Comparer/Endpoints/OutboundErrors/EndpointRouteBuilderExtensions.cs
+++ b/src/Comparer/Endpoints/OutboundErrors/EndpointRouteBuilderExtensions.cs
@@ -68,6 +68,8 @@ public static class EndpointRouteBuilderExtensions
     }
 
     [SuppressMessage("SonarLint", "S5131", Justification = "This service cannot be compromised by a malicious user")]
+    [SuppressMessage("SonarLint", "S1481", Justification = "Just testing for now")]
+    [SuppressMessage("SonarLint", "S125", Justification = "Just testing for now")]
     private static async Task<IResult> ReadAndSave(
         HttpContext context,
         Func<OutboundError, CancellationToken, Task> save,
@@ -81,13 +83,13 @@ public static class EndpointRouteBuilderExtensions
 
         try
         {
-            await save(new OutboundError(DateTime.UtcNow, xml), cancellationToken);
+            // await save(new OutboundError(DateTime.UtcNow, xml), cancellationToken);
         }
         catch (ConcurrencyException)
         {
             return Results.Conflict();
         }
 
-        return Results.Ok();
+        return Results.Conflict();
     }
 }

--- a/tests/Comparer.IntegrationTests/Consumers/FinalisationsConsumerTests.cs
+++ b/tests/Comparer.IntegrationTests/Consumers/FinalisationsConsumerTests.cs
@@ -64,7 +64,7 @@ public class FinalisationsConsumerTests(ITestOutputHelper output) : SqsTestBase(
         );
     }
 
-    [Fact]
+    [Fact(Skip = "Temporarily disabled to create a test build")]
     public async Task WhenFinalised_AndExistingDecisions()
     {
         var client = CreateClient();

--- a/tests/Comparer.IntegrationTests/Endpoints/DecisionTests.cs
+++ b/tests/Comparer.IntegrationTests/Endpoints/DecisionTests.cs
@@ -26,7 +26,7 @@ public class DecisionTests : IntegrationTestBase
         result.BtmsDecision.Should().BeNull();
     }
 
-    [Fact]
+    [Fact(Skip = "Temporarily disabled to create a test build")]
     public async Task WhenAlvsDecisions_ShouldReturnResults()
     {
         var client = CreateClient();
@@ -65,7 +65,7 @@ public class DecisionTests : IntegrationTestBase
         result.BtmsDecision.Should().BeNull();
     }
 
-    [Fact]
+    [Fact(Skip = "Temporarily disabled to create a test build")]
     public async Task WhenBtmsDecisions_ShouldReturnResults()
     {
         var client = CreateClient();

--- a/tests/Comparer.IntegrationTests/Endpoints/OutboundErrorTests.cs
+++ b/tests/Comparer.IntegrationTests/Endpoints/OutboundErrorTests.cs
@@ -25,7 +25,7 @@ public class OutboundErrorTests : IntegrationTestBase
         result.AlvsOutboundError.Should().BeNull();
     }
 
-    [Fact]
+    [Fact(Skip = "Temporarily disabled to create a test build")]
     public async Task WhenAlvsDecisions_ShouldReturnResults()
     {
         var client = CreateClient();
@@ -63,7 +63,7 @@ public class OutboundErrorTests : IntegrationTestBase
         result.BtmsOutboundError.Should().BeNull();
     }
 
-    [Fact]
+    [Fact(Skip = "Temporarily disabled to create a test build")]
     public async Task WhenBtmsDecisions_ShouldReturnResults()
     {
         var client = CreateClient();

--- a/tests/Comparer.IntegrationTests/Endpoints/ParityTests.cs
+++ b/tests/Comparer.IntegrationTests/Endpoints/ParityTests.cs
@@ -42,7 +42,7 @@ public class ParityTests(ITestOutputHelper output) : SqsTestBase(output)
         result.Stats.Should().BeNullOrEmpty();
     }
 
-    [Fact]
+    [Fact(Skip = "Temporarily disabled to create a test build")]
     public async Task WhenParityExists_ShouldReturnResults()
     {
         await DrainAllMessages();

--- a/tests/Comparer.Tests/Endpoints/Decisions/PutTests.cs
+++ b/tests/Comparer.Tests/Endpoints/Decisions/PutTests.cs
@@ -42,7 +42,7 @@ public class PutTests(ComparerWebApplicationFactory factory, ITestOutputHelper o
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
     }
 
-    [Fact]
+    [Fact(Skip = "Temporarily disabled to create a test build")]
     public async Task PutAlvs_WhenValid_ShouldBeRequestBodyAsResponse()
     {
         var client = CreateClient();
@@ -52,7 +52,7 @@ public class PutTests(ComparerWebApplicationFactory factory, ITestOutputHelper o
             new StringContent("<xml alvs=\"true\" />")
         );
 
-        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync();
 
         await Verify(content);
@@ -94,7 +94,7 @@ public class PutTests(ComparerWebApplicationFactory factory, ITestOutputHelper o
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
     }
 
-    [Fact]
+    [Fact(Skip = "Temporarily disabled to create a test build")]
     public async Task PutBtms_WhenValid_ShouldBeRequestBodyAsResponse()
     {
         var client = CreateClient();
@@ -104,7 +104,7 @@ public class PutTests(ComparerWebApplicationFactory factory, ITestOutputHelper o
             new StringContent("<xml btms=\"true\" />")
         );
 
-        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync();
 
         await Verify(content);

--- a/tests/Comparer.Tests/Endpoints/Decisions/PutTests.cs
+++ b/tests/Comparer.Tests/Endpoints/Decisions/PutTests.cs
@@ -52,7 +52,7 @@ public class PutTests(ComparerWebApplicationFactory factory, ITestOutputHelper o
             new StringContent("<xml alvs=\"true\" />")
         );
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
         var content = await response.Content.ReadAsStringAsync();
 
         await Verify(content);
@@ -104,7 +104,7 @@ public class PutTests(ComparerWebApplicationFactory factory, ITestOutputHelper o
             new StringContent("<xml btms=\"true\" />")
         );
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
         var content = await response.Content.ReadAsStringAsync();
 
         await Verify(content);

--- a/tests/Comparer.Tests/Endpoints/OutboundErrors/PutTests.cs
+++ b/tests/Comparer.Tests/Endpoints/OutboundErrors/PutTests.cs
@@ -58,7 +58,7 @@ public class PutTests(ComparerWebApplicationFactory factory, ITestOutputHelper o
             new StringContent("<xml alvs=\"true\" />")
         );
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
         var content = await response.Content.ReadAsStringAsync();
 
         await Verify(content);
@@ -116,7 +116,7 @@ public class PutTests(ComparerWebApplicationFactory factory, ITestOutputHelper o
             new StringContent("<xml alvs=\"true\" />")
         );
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
         var content = await response.Content.ReadAsStringAsync();
 
         await Verify(content);

--- a/tests/Comparer.Tests/Endpoints/OutboundErrors/PutTests.cs
+++ b/tests/Comparer.Tests/Endpoints/OutboundErrors/PutTests.cs
@@ -48,7 +48,7 @@ public class PutTests(ComparerWebApplicationFactory factory, ITestOutputHelper o
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
     }
 
-    [Fact]
+    [Fact(Skip = "Temporarily disabled to create a test build")]
     public async Task PutAlvs_WhenValid_ShouldBeRequestBodyAsResponse()
     {
         var client = CreateClient();
@@ -58,7 +58,7 @@ public class PutTests(ComparerWebApplicationFactory factory, ITestOutputHelper o
             new StringContent("<xml alvs=\"true\" />")
         );
 
-        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync();
 
         await Verify(content);
@@ -106,7 +106,7 @@ public class PutTests(ComparerWebApplicationFactory factory, ITestOutputHelper o
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
     }
 
-    [Fact]
+    [Fact(Skip = "Temporarily disabled to create a test build")]
     public async Task PutBtms_WhenValid_ShouldBeRequestBodyAsResponse()
     {
         var client = CreateClient();
@@ -116,7 +116,7 @@ public class PutTests(ComparerWebApplicationFactory factory, ITestOutputHelper o
             new StringContent("<xml alvs=\"true\" />")
         );
 
-        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync();
 
         await Verify(content);


### PR DESCRIPTION
- A test version of the service is required in Dev to facilitate Gateway behaviour testing when Comparer API returns 409. This change will be immediately reverted following this PR being merged