### PR TITLE
CDMS-657: Add new fields to the Comparison record

### DIFF
--- a/src/Comparer/Comparision/DecisionNumberMatch.cs
+++ b/src/Comparer/Comparision/DecisionNumberMatch.cs
@@ -1,0 +1,7 @@
+namespace Defra.TradeImportsDecisionComparer.Comparer.Comparision;
+
+public enum DecisionNumberMatch
+{
+    ExactMatch = 1,
+    Mismatch = 2,
+}

--- a/src/Comparer/Domain/Comparison.cs
+++ b/src/Comparer/Domain/Comparison.cs
@@ -9,18 +9,55 @@ public record Comparison(
     [property: JsonPropertyName("alvsXml")] string? AlvsXml,
     [property: JsonPropertyName("btmsXml")] string? BtmsXml,
     [property: JsonPropertyName("match")] ComparisionOutcome Match,
+    [property: JsonPropertyName("isFinalisation")] bool? IsFinalisation,
+    [property: JsonPropertyName("alvsTimestamp")] DateTime? AlvsTimestamp,
+    [property: JsonPropertyName("btmsTimestamp")] DateTime? BtmsTimestamp,
+    [property: JsonPropertyName("decisionNumberMatched")] DecisionNumberMatch? DecisionNumberMatched,
     [property: JsonPropertyName("reasons")] string[]? Reasons
 )
 {
     public static Comparison Create(string? alvsXml, string? btmsXml, Finalisation finalisation)
     {
         var alvsItems = Item.FromXml(alvsXml);
+        var alvsTimestamp = ServiceHeader.FromXml(alvsXml).ServiceCallTimestamp;
         var btmsItems = Item.FromXml(btmsXml);
-        var outcome = new ComparisionOutcomeEvaluatorContext(
+        var btmsTimestamp = ServiceHeader.FromXml(btmsXml).ServiceCallTimestamp;
+
+        var comparisonOutcome = new ComparisionOutcomeEvaluatorContext(
             alvsItems,
             btmsItems,
             finalisation
         ).GetComparisionOutcome();
-        return new Comparison(DateTime.UtcNow, alvsXml, btmsXml, outcome, []);
+
+        return new Comparison(
+            DateTime.UtcNow,
+            alvsXml,
+            btmsXml,
+            comparisonOutcome,
+            true,
+            alvsTimestamp,
+            btmsTimestamp,
+            GetDecisionNumberMatch(alvsXml, btmsXml, comparisonOutcome),
+            []
+        );
+    }
+
+    private static DecisionNumberMatch? GetDecisionNumberMatch(
+        string? alvsXml,
+        string? btmsXml,
+        ComparisionOutcome comparisionOutcome
+    )
+    {
+        if (comparisionOutcome is not (ComparisionOutcome.ExactMatch or ComparisionOutcome.GroupMatch))
+        {
+            return null;
+        }
+
+        var alvsDecisionNumber = Header.FromXml(alvsXml).DecisionNumber;
+        var btmsDecisionNumber = Header.FromXml(btmsXml).DecisionNumber;
+
+        return alvsDecisionNumber != null && btmsDecisionNumber != null && alvsDecisionNumber == btmsDecisionNumber
+            ? DecisionNumberMatch.ExactMatch
+            : DecisionNumberMatch.Mismatch;
     }
 }

--- a/src/Comparer/Domain/Header.cs
+++ b/src/Comparer/Domain/Header.cs
@@ -1,0 +1,23 @@
+using System.Text.Json.Serialization;
+using System.Xml;
+using System.Xml.Linq;
+using Defra.TradeImportsDecisionComparer.Comparer.Data.Extensions;
+using Defra.TradeImportsDecisionComparer.Comparer.Extensions;
+
+namespace Defra.TradeImportsDecisionComparer.Comparer.Domain;
+
+public record Header([property: JsonPropertyName("decisionNumber")] int? DecisionNumber)
+{
+    public static Header FromXml(string? xml)
+    {
+        if (xml == null)
+        {
+            return new Header(null as int?);
+        }
+
+        using var reader = XmlReader.Create(new StringReader(xml.ToHtmlDecodedXml()));
+        reader.ReadToFollowing(ElementNames.DecisionNumber.LocalName, ElementNames.DecisionNotification.NamespaceName);
+
+        return new Header(reader.ReadElementContentAsInt());
+    }
+}

--- a/src/Comparer/Domain/Item.cs
+++ b/src/Comparer/Domain/Item.cs
@@ -18,12 +18,12 @@ public record Item(
             return [];
         }
 
-        using XmlReader reader = XmlReader.Create(new StringReader(xml.ToHtmlDecodedXml()));
+        using var reader = XmlReader.Create(new StringReader(xml.ToHtmlDecodedXml()));
         reader.ReadToFollowing(
             ElementNames.DecisionNotification.LocalName,
             ElementNames.DecisionNotification.NamespaceName
         );
-        XElement element = XElement.Load(reader.ReadSubtree());
+        var element = XElement.Load(reader.ReadSubtree());
         return (
             from item in element.Descendants(ElementNames.Item)
             select new Item(

--- a/src/Comparer/Domain/ServiceHeader.cs
+++ b/src/Comparer/Domain/ServiceHeader.cs
@@ -1,0 +1,26 @@
+using System.Text.Json.Serialization;
+using System.Xml;
+using System.Xml.Linq;
+using Defra.TradeImportsDecisionComparer.Comparer.Data.Extensions;
+using Defra.TradeImportsDecisionComparer.Comparer.Extensions;
+
+namespace Defra.TradeImportsDecisionComparer.Comparer.Domain;
+
+public record ServiceHeader([property: JsonPropertyName("serviceCallTimestamp")] DateTime? ServiceCallTimestamp)
+{
+    public static ServiceHeader FromXml(string? xml)
+    {
+        if (xml == null)
+        {
+            return new ServiceHeader(null as DateTime?);
+        }
+
+        using var reader = XmlReader.Create(new StringReader(xml.ToHtmlDecodedXml()));
+        reader.ReadToFollowing(
+            ElementNames.ServiceCallTimestamp.LocalName,
+            ElementNames.DecisionNotification.NamespaceName
+        );
+
+        return new ServiceHeader(reader.ReadElementContentAsDateTime());
+    }
+}

--- a/src/Comparer/Extensions/ElementNames.cs
+++ b/src/Comparer/Extensions/ElementNames.cs
@@ -5,6 +5,8 @@ namespace Defra.TradeImportsDecisionComparer.Comparer.Extensions;
 public static class ElementNames
 {
     public static readonly string Namespace = "http://www.hmrc.gov.uk/webservices/itsw/ws/decisionnotification";
+    public static readonly XName ServiceHeader = XName.Get(nameof(ServiceHeader), Namespace);
+    public static readonly XName ServiceCallTimestamp = XName.Get(nameof(ServiceCallTimestamp), Namespace);
     public static readonly XName DecisionNotification = XName.Get(nameof(DecisionNotification), Namespace);
     public static readonly XName Item = XName.Get(nameof(Item), Namespace);
     public static readonly XName Check = XName.Get(nameof(Check), Namespace);

--- a/tests/Comparer.Tests/Comparision/ComparisonTests.cs
+++ b/tests/Comparer.Tests/Comparision/ComparisonTests.cs
@@ -6,15 +6,15 @@ namespace Defra.TradeImportsDecisionComparer.Comparer.Tests.Comparision;
 
 public class ComparisonTests
 {
-    private const string sampleDecision =
+    private const string SampleDecision =
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<NS1:Envelope xmlns:NS1=\"http://www.w3.org/2003/05/soap-envelope\">\n  <NS1:Header>\n    <NS2:Security xmlns:NS2=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\" NS1:role=\"system\">\n      <NS2:UsernameToken>\n        <NS2:Username>ibmtest</NS2:Username>\n        <NS2:Password>password</NS2:Password>\n      </NS2:UsernameToken>\n    </NS2:Security>\n  </NS1:Header>\n  <NS1:Body>\n    <NS3:DecisionNotification xmlns:NS3=\"http://uk.gov.hmrc.ITSW2.ws\">&lt;NS2:DecisionNotification xmlns:NS2=&quot;http://www.hmrc.gov.uk/webservices/itsw/ws/decisionnotification&quot;&gt;&lt;NS2:ServiceHeader&gt;&lt;NS2:SourceSystem&gt;ALVS&lt;/NS2:SourceSystem&gt;&lt;NS2:DestinationSystem&gt;CDS&lt;/NS2:DestinationSystem&gt;&lt;NS2:CorrelationId&gt;000&lt;/NS2:CorrelationId&gt;&lt;NS2:ServiceCallTimestamp&gt;2025-05-29T18:57:29.298&lt;/NS2:ServiceCallTimestamp&gt;&lt;/NS2:ServiceHeader&gt;&lt;NS2:Header&gt;&lt;NS2:EntryReference&gt;25GB1HG99NHUJO3999&lt;/NS2:EntryReference&gt;&lt;NS2:EntryVersionNumber&gt;3&lt;/NS2:EntryVersionNumber&gt;&lt;NS2:DecisionNumber&gt;3&lt;/NS2:DecisionNumber&gt;&lt;/NS2:Header&gt;&lt;NS2:Item&gt;&lt;NS2:ItemNumber&gt;1&lt;/NS2:ItemNumber&gt;&lt;NS2:Check&gt;&lt;NS2:CheckCode&gt;H219&lt;/NS2:CheckCode&gt;&lt;NS2:DecisionCode&gt;H02&lt;/NS2:DecisionCode&gt;&lt;/NS2:Check&gt;&lt;/NS2:Item&gt;&lt;/NS2:DecisionNotification&gt;</NS3:DecisionNotification>\n  </NS1:Body>\n</NS1:Envelope>";
 
     [Fact]
     public void WhenDecisionAreTheSameThenShouldReturnExactMatch()
     {
         var result = Comparison.Create(
-            sampleDecision,
-            sampleDecision,
+            SampleDecision,
+            SampleDecision,
             new Finalisation()
             {
                 FinalState = "3",
@@ -30,7 +30,7 @@ public class ComparisonTests
     public void WhenNoBtmsDecisionThenShouldReturnNoBtmsDecision()
     {
         var result = Comparison.Create(
-            sampleDecision,
+            SampleDecision,
             null,
             new Finalisation()
             {
@@ -48,7 +48,7 @@ public class ComparisonTests
     {
         var result = Comparison.Create(
             null,
-            sampleDecision,
+            SampleDecision,
             new Finalisation()
             {
                 FinalState = "3",
@@ -61,11 +61,11 @@ public class ComparisonTests
     }
 
     [Fact]
-    public void WhenMrnIsCancelledThenShouldReturnCanceledMrn()
+    public void WhenMrnIsCancelledThenShouldReturnCancelledMrn()
     {
         var result = Comparison.Create(
-            sampleDecision,
-            sampleDecision,
+            SampleDecision,
+            SampleDecision,
             new Finalisation()
             {
                 FinalState = "1",
@@ -75,5 +75,81 @@ public class ComparisonTests
         );
 
         result.Match.Should().Be(ComparisionOutcome.CancelledMrn);
+    }
+
+    [Fact]
+    public void WhenDecisionNumberMatches_AndDecisionIsExactMatch_DecisionNumberMatchedShouldBeExactMatch()
+    {
+        var result = Comparison.Create(
+            SampleDecision,
+            SampleDecision,
+            new Finalisation()
+            {
+                FinalState = "3",
+                ExternalVersion = 1,
+                IsManualRelease = false,
+            }
+        );
+
+        result.Match.Should().Be(ComparisionOutcome.ExactMatch);
+        result.DecisionNumberMatched.Should().Be(DecisionNumberMatch.ExactMatch);
+    }
+
+    [Fact]
+    public void WhenDecisionNumberMatches_AndDecisionIsGroupMatch_DecisionNumberMatchedShouldBeExactMatch()
+    {
+        var btmsDecision = SampleDecision.Replace("NS2:DecisionCode&gt;H02&lt", "NS2:DecisionCode&gt;H03&lt");
+
+        var result = Comparison.Create(
+            SampleDecision,
+            btmsDecision,
+            new Finalisation()
+            {
+                FinalState = "3",
+                ExternalVersion = 1,
+                IsManualRelease = false,
+            }
+        );
+
+        result.Match.Should().Be(ComparisionOutcome.GroupMatch);
+        result.DecisionNumberMatched.Should().Be(DecisionNumberMatch.ExactMatch);
+    }
+
+    [Fact]
+    public void WhenDecisionNumberDoesNotMatch_DecisionNumberMatchedShouldBeMismatch()
+    {
+        var btmsDecision = SampleDecision.Replace("NS2:DecisionNumber&gt;3&lt", "NS2:DecisionNumber&gt;2&lt");
+
+        var result = Comparison.Create(
+            SampleDecision,
+            btmsDecision,
+            new Finalisation()
+            {
+                FinalState = "3",
+                ExternalVersion = 1,
+                IsManualRelease = false,
+            }
+        );
+
+        result.DecisionNumberMatched.Should().Be(DecisionNumberMatch.Mismatch);
+    }
+
+    [Fact]
+    public void WhenDecisionsDoNotMatch_ButTheDecisionNumberMatches_DecisionNumberMatchedShouldBeNull()
+    {
+        var btmsDecision = SampleDecision.Replace("&lt;NS2:CheckCode&gt;H219&lt", "&lt;NS2:CheckCode&gt;H220&lt");
+
+        var result = Comparison.Create(
+            SampleDecision,
+            btmsDecision,
+            new Finalisation()
+            {
+                FinalState = "3",
+                ExternalVersion = 1,
+                IsManualRelease = false,
+            }
+        );
+
+        result.DecisionNumberMatched.Should().BeNull();
     }
 }

--- a/tests/Comparer.Tests/Domain/HeaderTests.cs
+++ b/tests/Comparer.Tests/Domain/HeaderTests.cs
@@ -1,29 +1,16 @@
 using Defra.TradeImportsDecisionComparer.Comparer.Domain;
 
-namespace Defra.TradeImportsDecisionComparer.Comparer.Tests.Comparision;
+namespace Defra.TradeImportsDecisionComparer.Comparer.Tests.Domain;
 
-public class ItemTests
+public class HeaderTests
 {
-    private const string sampleDecision =
+    private const string SampleDecision =
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<NS1:Envelope xmlns:NS1=\"http://www.w3.org/2003/05/soap-envelope\">\n  <NS1:Header>\n    <NS2:Security xmlns:NS2=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\" NS1:role=\"system\">\n      <NS2:UsernameToken>\n        <NS2:Username>ibmtest</NS2:Username>\n        <NS2:Password>password</NS2:Password>\n      </NS2:UsernameToken>\n    </NS2:Security>\n  </NS1:Header>\n  <NS1:Body>\n    <NS3:DecisionNotification xmlns:NS3=\"http://uk.gov.hmrc.ITSW2.ws\">&lt;NS2:DecisionNotification xmlns:NS2=&quot;http://www.hmrc.gov.uk/webservices/itsw/ws/decisionnotification&quot;&gt;&lt;NS2:ServiceHeader&gt;&lt;NS2:SourceSystem&gt;ALVS&lt;/NS2:SourceSystem&gt;&lt;NS2:DestinationSystem&gt;CDS&lt;/NS2:DestinationSystem&gt;&lt;NS2:CorrelationId&gt;000&lt;/NS2:CorrelationId&gt;&lt;NS2:ServiceCallTimestamp&gt;2025-05-29T18:57:29.298&lt;/NS2:ServiceCallTimestamp&gt;&lt;/NS2:ServiceHeader&gt;&lt;NS2:Header&gt;&lt;NS2:EntryReference&gt;25GB1HG99NHUJO3999&lt;/NS2:EntryReference&gt;&lt;NS2:EntryVersionNumber&gt;3&lt;/NS2:EntryVersionNumber&gt;&lt;NS2:DecisionNumber&gt;3&lt;/NS2:DecisionNumber&gt;&lt;/NS2:Header&gt;&lt;NS2:Item&gt;&lt;NS2:ItemNumber&gt;1&lt;/NS2:ItemNumber&gt;&lt;NS2:Check&gt;&lt;NS2:CheckCode&gt;H219&lt;/NS2:CheckCode&gt;&lt;NS2:DecisionCode&gt;H02&lt;/NS2:DecisionCode&gt;&lt;/NS2:Check&gt;&lt;/NS2:Item&gt;&lt;/NS2:DecisionNotification&gt;</NS3:DecisionNotification>\n  </NS1:Body>\n</NS1:Envelope>";
 
     [Fact]
-    public void WhenXmlIsNull_ReturnEmptyList()
+    public void FromXml_ReturnsHeader()
     {
-        var result = Item.FromXml(null);
-
-        result.Count.Should().Be(0);
-    }
-
-    [Fact]
-    public void WhenXmlIsHasValue_ReturnItems()
-    {
-        var result = Item.FromXml(sampleDecision);
-
-        result.Count.Should().Be(1);
-        result[0].ItemNumber.Should().Be(1);
-        result[0].Checks.Count.Should().Be(1);
-        result[0].Checks[0].CheckCode.Should().Be("H219");
-        result[0].Checks[0].DecisionCode.Should().Be("H02");
+        var header = Header.FromXml(SampleDecision);
+        header.DecisionNumber.Should().Be(3);
     }
 }

--- a/tests/Comparer.Tests/Domain/ItemTests.cs
+++ b/tests/Comparer.Tests/Domain/ItemTests.cs
@@ -1,0 +1,29 @@
+using Defra.TradeImportsDecisionComparer.Comparer.Domain;
+
+namespace Defra.TradeImportsDecisionComparer.Comparer.Tests.Domain;
+
+public class ItemTests
+{
+    private const string sampleDecision =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<NS1:Envelope xmlns:NS1=\"http://www.w3.org/2003/05/soap-envelope\">\n  <NS1:Header>\n    <NS2:Security xmlns:NS2=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\" NS1:role=\"system\">\n      <NS2:UsernameToken>\n        <NS2:Username>ibmtest</NS2:Username>\n        <NS2:Password>password</NS2:Password>\n      </NS2:UsernameToken>\n    </NS2:Security>\n  </NS1:Header>\n  <NS1:Body>\n    <NS3:DecisionNotification xmlns:NS3=\"http://uk.gov.hmrc.ITSW2.ws\">&lt;NS2:DecisionNotification xmlns:NS2=&quot;http://www.hmrc.gov.uk/webservices/itsw/ws/decisionnotification&quot;&gt;&lt;NS2:ServiceHeader&gt;&lt;NS2:SourceSystem&gt;ALVS&lt;/NS2:SourceSystem&gt;&lt;NS2:DestinationSystem&gt;CDS&lt;/NS2:DestinationSystem&gt;&lt;NS2:CorrelationId&gt;000&lt;/NS2:CorrelationId&gt;&lt;NS2:ServiceCallTimestamp&gt;2025-05-29T18:57:29.298&lt;/NS2:ServiceCallTimestamp&gt;&lt;/NS2:ServiceHeader&gt;&lt;NS2:Header&gt;&lt;NS2:EntryReference&gt;25GB1HG99NHUJO3999&lt;/NS2:EntryReference&gt;&lt;NS2:EntryVersionNumber&gt;3&lt;/NS2:EntryVersionNumber&gt;&lt;NS2:DecisionNumber&gt;3&lt;/NS2:DecisionNumber&gt;&lt;/NS2:Header&gt;&lt;NS2:Item&gt;&lt;NS2:ItemNumber&gt;1&lt;/NS2:ItemNumber&gt;&lt;NS2:Check&gt;&lt;NS2:CheckCode&gt;H219&lt;/NS2:CheckCode&gt;&lt;NS2:DecisionCode&gt;H02&lt;/NS2:DecisionCode&gt;&lt;/NS2:Check&gt;&lt;/NS2:Item&gt;&lt;/NS2:DecisionNotification&gt;</NS3:DecisionNotification>\n  </NS1:Body>\n</NS1:Envelope>";
+
+    [Fact]
+    public void WhenXmlIsNull_ReturnEmptyList()
+    {
+        var result = Item.FromXml(null);
+
+        result.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public void WhenXmlIsHasValue_ReturnItems()
+    {
+        var result = Item.FromXml(sampleDecision);
+
+        result.Count.Should().Be(1);
+        result[0].ItemNumber.Should().Be(1);
+        result[0].Checks.Count.Should().Be(1);
+        result[0].Checks[0].CheckCode.Should().Be("H219");
+        result[0].Checks[0].DecisionCode.Should().Be("H02");
+    }
+}

--- a/tests/Comparer.Tests/Domain/ServiceHeaderTests.cs
+++ b/tests/Comparer.Tests/Domain/ServiceHeaderTests.cs
@@ -1,0 +1,16 @@
+using Defra.TradeImportsDecisionComparer.Comparer.Domain;
+
+namespace Defra.TradeImportsDecisionComparer.Comparer.Tests.Domain;
+
+public class ServiceHeaderTests
+{
+    private const string SampleDecision =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<NS1:Envelope xmlns:NS1=\"http://www.w3.org/2003/05/soap-envelope\">\n  <NS1:Header>\n    <NS2:Security xmlns:NS2=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\" NS1:role=\"system\">\n      <NS2:UsernameToken>\n        <NS2:Username>ibmtest</NS2:Username>\n        <NS2:Password>password</NS2:Password>\n      </NS2:UsernameToken>\n    </NS2:Security>\n  </NS1:Header>\n  <NS1:Body>\n    <NS3:DecisionNotification xmlns:NS3=\"http://uk.gov.hmrc.ITSW2.ws\">&lt;NS2:DecisionNotification xmlns:NS2=&quot;http://www.hmrc.gov.uk/webservices/itsw/ws/decisionnotification&quot;&gt;&lt;NS2:ServiceHeader&gt;&lt;NS2:SourceSystem&gt;ALVS&lt;/NS2:SourceSystem&gt;&lt;NS2:DestinationSystem&gt;CDS&lt;/NS2:DestinationSystem&gt;&lt;NS2:CorrelationId&gt;000&lt;/NS2:CorrelationId&gt;&lt;NS2:ServiceCallTimestamp&gt;2025-05-29T18:57:29.298&lt;/NS2:ServiceCallTimestamp&gt;&lt;/NS2:ServiceHeader&gt;&lt;NS2:Header&gt;&lt;NS2:EntryReference&gt;25GB1HG99NHUJO3999&lt;/NS2:EntryReference&gt;&lt;NS2:EntryVersionNumber&gt;3&lt;/NS2:EntryVersionNumber&gt;&lt;NS2:DecisionNumber&gt;3&lt;/NS2:DecisionNumber&gt;&lt;/NS2:Header&gt;&lt;NS2:Item&gt;&lt;NS2:ItemNumber&gt;1&lt;/NS2:ItemNumber&gt;&lt;NS2:Check&gt;&lt;NS2:CheckCode&gt;H219&lt;/NS2:CheckCode&gt;&lt;NS2:DecisionCode&gt;H02&lt;/NS2:DecisionCode&gt;&lt;/NS2:Check&gt;&lt;/NS2:Item&gt;&lt;/NS2:DecisionNotification&gt;</NS3:DecisionNotification>\n  </NS1:Body>\n</NS1:Envelope>";
+
+    [Fact]
+    public void FromXml_ReturnsServiceHeader()
+    {
+        var serviceHeader = ServiceHeader.FromXml(SampleDecision);
+        serviceHeader.ServiceCallTimestamp.Should().Be(new DateTime(2025, 05, 29, 18, 57, 29, 298, DateTimeKind.Utc));
+    }
+}

--- a/tests/Comparer.Tests/Endpoints/Comparisons/GetTests.Get_WhenAuthorized_ShouldBeOk.verified.json
+++ b/tests/Comparer.Tests/Endpoints/Comparisons/GetTests.Get_WhenAuthorized_ShouldBeOk.verified.json
@@ -8,6 +8,10 @@
     "alvsXml": "<xml alvs=\"true\"/>",
     "btmsXml": "<xml btms=\"true\"/>",
     "match": "ExactMatch",
+    "isFinalisation": true,
+    "alvsTimestamp": "2025-04-23T08:15:00Z",
+    "btmsTimestamp": "2025-04-23T08:30:00Z",
+    "decisionNumberMatched": "ExactMatch",
     "reasons": [
       "Reason 1",
       "Reason 2"

--- a/tests/Comparer.Tests/Endpoints/Comparisons/GetTests.cs
+++ b/tests/Comparer.Tests/Endpoints/Comparisons/GetTests.cs
@@ -59,6 +59,10 @@ public class GetTests(ComparerWebApplicationFactory factory, ITestOutputHelper o
                         "<xml alvs=\"true\"/>",
                         "<xml btms=\"true\"/>",
                         ComparisionOutcome.ExactMatch,
+                        true,
+                        new DateTime(2025, 4, 23, 8, 15, 0, DateTimeKind.Utc),
+                        new DateTime(2025, 4, 23, 8, 30, 0, DateTimeKind.Utc),
+                        DecisionNumberMatch.ExactMatch,
                         ["Reason 1", "Reason 2"]
                     ),
                 }


### PR DESCRIPTION
We want to compare whether the DecisionNumber matched along with identifying whether ALVS or BTMS created a decision first, therefore new fields have been added.