### PR TITLE
CDMS-657: Generate comparison when receiving ALVS decisions

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -66,7 +66,6 @@ services:
       DEBUG: ${DEBUG:-1}
       LS_LOG: info # Localstack DEBUG Level
       SERVICES: sqs
-      LOCALSTACK_HOST: 127.0.0.1
       TZ: Europe/London
     volumes:
       - '${TMPDIR:-/tmp}/localstack:/var/lib/localstack'

--- a/src/Comparer/Comparision/ComparisionOutcome.cs
+++ b/src/Comparer/Comparision/ComparisionOutcome.cs
@@ -13,13 +13,17 @@ public enum ComparisionOutcome
     CancelledMrn = 6,
 }
 
-public record ComparisionOutcomeEvaluatorContext(List<Item> AlvsItems, List<Item> BtmsItems, Finalisation Finalisation);
+public record ComparisionOutcomeEvaluatorContext(
+    List<Item> AlvsItems,
+    List<Item> BtmsItems,
+    Finalisation? Finalisation
+);
 
 public static class ComparisionOutcomeEvaluator
 {
     public static ComparisionOutcome GetComparisionOutcome(this ComparisionOutcomeEvaluatorContext context)
     {
-        if (context.Finalisation.FinalState is "1" or "2")
+        if (context.Finalisation?.FinalState is "1" or "2")
         {
             return ComparisionOutcome.CancelledMrn;
         }

--- a/src/Comparer/Consumers/FinalisationsConsumer.cs
+++ b/src/Comparer/Consumers/FinalisationsConsumer.cs
@@ -1,22 +1,15 @@
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
 using Defra.TradeImportsDataApi.Domain.Events;
-using Defra.TradeImportsDecisionComparer.Comparer.Domain;
-using Defra.TradeImportsDecisionComparer.Comparer.Entities;
-using Defra.TradeImportsDecisionComparer.Comparer.Extensions;
 using Defra.TradeImportsDecisionComparer.Comparer.Services;
 using SlimMessageBus;
 
 namespace Defra.TradeImportsDecisionComparer.Comparer.Consumers;
 
-[ExcludeFromCodeCoverage] // see integration tests
 // ReSharper disable once ClassNeverInstantiated.Global
-public class FinalisationsConsumer(
-    IDecisionService decisionService,
-    IComparisonService comparisonService,
-    ILogger<FinalisationsConsumer> logger
-) : IConsumer<JsonElement>, IConsumerWithContext
+public class FinalisationsConsumer(IComparisonManager comparisonManager, ILogger<FinalisationsConsumer> logger)
+    : IConsumer<JsonElement>,
+        IConsumerWithContext
 {
     public async Task OnHandle(JsonElement received, CancellationToken cancellationToken)
     {
@@ -27,26 +20,7 @@ public class FinalisationsConsumer(
         logger.LogInformation("Received finalisation for {ResourceId}", message.ResourceId);
 
         var finalisation = message.Resource?.Finalisation;
-
-        var alvsDecision = await decisionService.GetAlvsDecision(message.ResourceId, cancellationToken);
-        var btmsDecision = await decisionService.GetBtmsDecision(message.ResourceId, cancellationToken);
-        var latestAlvs = alvsDecision?.Decisions.OrderBy(x => x.Xml.GetDecisionNumber()).LastOrDefault();
-        var latestBtms = btmsDecision?.Decisions.OrderBy(x => x.Xml.GetDecisionNumber()).LastOrDefault();
-
-        var comparison = Comparison.Create(latestAlvs?.Xml, latestBtms?.Xml, finalisation!);
-        var comparisonEntity = await comparisonService.Get(message.ResourceId, cancellationToken);
-
-        if (comparisonEntity is null)
-        {
-            comparisonEntity = new ComparisonEntity { Id = message.ResourceId, Latest = comparison };
-        }
-        else
-        {
-            comparisonEntity.History.Add(comparisonEntity.Latest);
-            comparisonEntity.Latest = comparison;
-        }
-
-        await comparisonService.Save(comparisonEntity, cancellationToken);
+        await comparisonManager.CreateUpdateComparisonEntity(message.ResourceId, finalisation, cancellationToken);
     }
 
     public required IConsumerContext Context { get; set; }

--- a/src/Comparer/Domain/Comparison.cs
+++ b/src/Comparer/Domain/Comparison.cs
@@ -16,7 +16,7 @@ public record Comparison(
     [property: JsonPropertyName("reasons")] string[]? Reasons
 )
 {
-    public static Comparison Create(string? alvsXml, string? btmsXml, Finalisation finalisation)
+    public static Comparison Create(string? alvsXml, string? btmsXml, Finalisation? finalisation)
     {
         var alvsItems = Item.FromXml(alvsXml);
         var alvsTimestamp = ServiceHeader.FromXml(alvsXml).ServiceCallTimestamp;
@@ -34,7 +34,7 @@ public record Comparison(
             alvsXml,
             btmsXml,
             comparisonOutcome,
-            true,
+            finalisation != null,
             alvsTimestamp,
             btmsTimestamp,
             GetDecisionNumberMatch(alvsXml, btmsXml, comparisonOutcome),

--- a/src/Comparer/Domain/Item.cs
+++ b/src/Comparer/Domain/Item.cs
@@ -23,6 +23,12 @@ public record Item(
             ElementNames.DecisionNotification.LocalName,
             ElementNames.DecisionNotification.NamespaceName
         );
+
+        if (reader.NodeType != XmlNodeType.Element)
+        {
+            return [];
+        }
+
         var element = XElement.Load(reader.ReadSubtree());
         return (
             from item in element.Descendants(ElementNames.Item)

--- a/src/Comparer/Domain/ServiceHeader.cs
+++ b/src/Comparer/Domain/ServiceHeader.cs
@@ -8,11 +8,13 @@ namespace Defra.TradeImportsDecisionComparer.Comparer.Domain;
 
 public record ServiceHeader([property: JsonPropertyName("serviceCallTimestamp")] DateTime? ServiceCallTimestamp)
 {
+    private static readonly ServiceHeader s_emptyServiceHeader = new(null as DateTime?);
+
     public static ServiceHeader FromXml(string? xml)
     {
         if (xml == null)
         {
-            return new ServiceHeader(null as DateTime?);
+            return s_emptyServiceHeader;
         }
 
         using var reader = XmlReader.Create(new StringReader(xml.ToHtmlDecodedXml()));
@@ -20,6 +22,11 @@ public record ServiceHeader([property: JsonPropertyName("serviceCallTimestamp")]
             ElementNames.ServiceCallTimestamp.LocalName,
             ElementNames.DecisionNotification.NamespaceName
         );
+
+        if (reader.NodeType != XmlNodeType.Element)
+        {
+            return s_emptyServiceHeader;
+        }
 
         return new ServiceHeader(reader.ReadElementContentAsDateTime());
     }

--- a/src/Comparer/Endpoints/Decisions/EndpointRouteBuilderExtensions.cs
+++ b/src/Comparer/Endpoints/Decisions/EndpointRouteBuilderExtensions.cs
@@ -24,8 +24,18 @@ public static class EndpointRouteBuilderExtensions
         [FromRoute] string mrn,
         HttpContext context,
         [FromServices] IDecisionService decisionService,
+        [FromServices] IComparisonManager comparisonManager,
         CancellationToken cancellationToken
-    ) => await ReadAndSave(context, (d, ct) => decisionService.AppendAlvsDecision(mrn, d, ct), cancellationToken);
+    )
+    {
+        var result = await ReadAndSave(
+            context,
+            (d, ct) => decisionService.AppendAlvsDecision(mrn, d, ct),
+            cancellationToken
+        );
+        await comparisonManager.CreateUpdateComparisonEntity(mrn, null, cancellationToken);
+        return result;
+    }
 
     [HttpPut]
     private static async Task<IResult> PutBtms(

--- a/src/Comparer/Extensions/ElementExtensions.cs
+++ b/src/Comparer/Extensions/ElementExtensions.cs
@@ -32,19 +32,23 @@ public static class ElementExtensions
 
     public static int GetDecisionNumber(this string xml)
     {
-        using XmlReader reader = XmlReader.Create(new StringReader(xml.ToHtmlDecodedXml()));
+        using var reader = XmlReader.Create(new StringReader(xml.ToHtmlDecodedXml()));
         reader.ReadToFollowing(
             ElementNames.DecisionNotification.LocalName,
             ElementNames.DecisionNotification.NamespaceName
         );
 
-        XElement element = XElement.Load(reader.ReadSubtree());
+        if (reader.NodeType != XmlNodeType.Element)
+            return 0;
+
+        var element = XElement.Load(reader.ReadSubtree());
         var decisionNumberElement = element
             .Descendants(ElementNames.Header)
             .Descendants(ElementNames.DecisionNumber)
             .FirstOrDefault();
+
         if (decisionNumberElement?.Value != null)
-            return Int32.Parse(decisionNumberElement.Value);
+            return int.Parse(decisionNumberElement.Value);
 
         return 0;
     }

--- a/src/Comparer/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Comparer/Extensions/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Defra.TradeImportsDecisionComparer.Comparer.Configuration;
 using Defra.TradeImportsDecisionComparer.Comparer.Consumers;
 using Defra.TradeImportsDecisionComparer.Comparer.Metrics;
+using Defra.TradeImportsDecisionComparer.Comparer.Services;
 using Defra.TradeImportsDecisionComparer.Comparer.Utils.Logging;
 using SlimMessageBus.Host;
 using SlimMessageBus.Host.AmazonSQS;

--- a/src/Comparer/Program.cs
+++ b/src/Comparer/Program.cs
@@ -97,6 +97,7 @@ static void ConfigureWebApplication(WebApplicationBuilder builder, string[] args
     builder.Services.AddTransient<IOutboundErrorService, OutboundErrorService>();
     builder.Services.AddTransient<IDecisionService, DecisionService>();
     builder.Services.AddTransient<IComparisonService, ComparisonService>();
+    builder.Services.AddTransient<IComparisonManager, ComparisonManager>();
 
     builder.Services.AddTransient<MetricsMiddleware>();
     builder.Services.AddSingleton<RequestMetrics>();

--- a/src/Comparer/Properties/launchSettings.json
+++ b/src/Comparer/Properties/launchSettings.json
@@ -4,7 +4,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": false,
-      "applicationUrl": "http://localhost:5000",
+      "applicationUrl": "http://localhost:8080",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "AWS_ACCESS_KEY_ID": "test",
@@ -12,7 +12,11 @@
         "AWS_REGION": "eu-west-2",
         "AWS_SECRET_ACCESS_KEY": "test",
         "ENVIRONMENT": "local",
-        "SQS_ENDPOINT": "http://localhost:4566"
+        "SQS_ENDPOINT": "http://localhost:4566",
+
+        "Acl__Clients__IntegrationTests__Secret": "integration-tests-pwd",
+        "Acl__Clients__IntegrationTests__Scopes__0": "read",
+        "Acl__Clients__IntegrationTests__Scopes__1": "write"
       }
     }
   }

--- a/src/Comparer/Services/ComparisonManager.cs
+++ b/src/Comparer/Services/ComparisonManager.cs
@@ -1,0 +1,39 @@
+using System.Diagnostics.CodeAnalysis;
+using Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
+using Defra.TradeImportsDecisionComparer.Comparer.Domain;
+using Defra.TradeImportsDecisionComparer.Comparer.Entities;
+using Defra.TradeImportsDecisionComparer.Comparer.Extensions;
+
+namespace Defra.TradeImportsDecisionComparer.Comparer.Services;
+
+[ExcludeFromCodeCoverage] // see integration tests
+public class ComparisonManager(IDecisionService decisionService, IComparisonService comparisonService)
+    : IComparisonManager
+{
+    public async Task CreateUpdateComparisonEntity(
+        string mrn,
+        Finalisation? finalisation,
+        CancellationToken cancellationToken
+    )
+    {
+        var alvsDecision = await decisionService.GetAlvsDecision(mrn, cancellationToken);
+        var btmsDecision = await decisionService.GetBtmsDecision(mrn, cancellationToken);
+        var latestAlvs = alvsDecision?.Decisions.OrderBy(x => x.Xml.GetDecisionNumber()).LastOrDefault();
+        var latestBtms = btmsDecision?.Decisions.OrderBy(x => x.Xml.GetDecisionNumber()).LastOrDefault();
+
+        var comparison = Comparison.Create(latestAlvs?.Xml, latestBtms?.Xml, finalisation);
+        var comparisonEntity = await comparisonService.Get(mrn, cancellationToken);
+
+        if (comparisonEntity is null)
+        {
+            comparisonEntity = new ComparisonEntity { Id = mrn, Latest = comparison };
+        }
+        else
+        {
+            comparisonEntity.History.Add(comparisonEntity.Latest);
+            comparisonEntity.Latest = comparison;
+        }
+
+        await comparisonService.Save(comparisonEntity, cancellationToken);
+    }
+}

--- a/src/Comparer/Services/IComparisonManager.cs
+++ b/src/Comparer/Services/IComparisonManager.cs
@@ -1,0 +1,12 @@
+using Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
+
+namespace Defra.TradeImportsDecisionComparer.Comparer.Services;
+
+public interface IComparisonManager
+{
+    public Task CreateUpdateComparisonEntity(
+        string mrn,
+        Finalisation? finalisation,
+        CancellationToken cancellationToken
+    );
+}

--- a/tests/Comparer.IntegrationTests/AsyncWaiter.cs
+++ b/tests/Comparer.IntegrationTests/AsyncWaiter.cs
@@ -13,8 +13,15 @@ public static class AsyncWaiter
 
         while (true)
         {
-            if (await condition())
-                return true;
+            try
+            {
+                if (await condition())
+                    return true;
+            }
+            catch
+            {
+                // ignored
+            }
 
             if (timer.Elapsed > s_defaultTimeout)
                 return false;

--- a/tests/Comparer.IntegrationTests/Consumers/FinalisationsConsumerTests.cs
+++ b/tests/Comparer.IntegrationTests/Consumers/FinalisationsConsumerTests.cs
@@ -105,7 +105,8 @@ public class FinalisationsConsumerTests(ITestOutputHelper output) : SqsTestBase(
             await AsyncWaiter.WaitForAsync(async () =>
             {
                 response = await client.GetAsync(Testing.Endpoints.Decisions.Comparison(mrn));
-                response.StatusCode.Should().Be(HttpStatusCode.OK);
+                if (response.StatusCode != HttpStatusCode.OK)
+                    return false;
 
                 var content = await response.Content.ReadAsStringAsync();
                 if (string.IsNullOrEmpty(content))
@@ -160,7 +161,10 @@ public class FinalisationsConsumerTests(ITestOutputHelper output) : SqsTestBase(
 
                 return entity
                     is {
-                        History: [{ AlvsXml: SampleDecision, BtmsXml: SampleDecision }],
+                        History: [
+                            { AlvsXml: SampleDecision, IsFinalisation: false },
+                            { AlvsXml: SampleDecision, BtmsXml: SampleDecision, IsFinalisation: true },
+                        ],
                         Latest: { AlvsXml: SampleDecision, BtmsXml: SampleDecision }
                     };
             })

--- a/tests/Comparer.IntegrationTests/Endpoints/DecisionTests.cs
+++ b/tests/Comparer.IntegrationTests/Endpoints/DecisionTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Defra.TradeImportsDecisionComparer.Comparer.Entities;
 using FluentAssertions;
 
@@ -8,7 +9,11 @@ namespace Defra.TradeImportsDecisionComparer.Comparer.IntegrationTests.Endpoints
 
 public class DecisionTests : IntegrationTestBase
 {
-    private static readonly JsonSerializerOptions s_options = new() { PropertyNameCaseInsensitive = true };
+    private static readonly JsonSerializerOptions s_options = new()
+    {
+        Converters = { new JsonStringEnumConverter() },
+        PropertyNameCaseInsensitive = true,
+    };
 
     [Fact]
     public async Task WhenNoDecisions_ShouldBeNullResults()
@@ -63,6 +68,51 @@ public class DecisionTests : IntegrationTestBase
         result.AlvsDecision.Should().NotBeNull();
         result.AlvsDecision.Decisions.Should().HaveCount(2);
         result.BtmsDecision.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task WhenPutAlvsDecision_ItShouldCreateAComparison()
+    {
+        var client = CreateClient();
+        var mrn = Guid.NewGuid().ToString("N");
+
+        const string decisionOne = "<xml decision=\"1\" />";
+        const string decisionTwo = "<xml decision=\"2\" />";
+
+        var response = await client.PutAsync(
+            Testing.Endpoints.Decisions.Alvs.Put(mrn),
+            new StringContent(decisionOne, Encoding.UTF8, "application/xml")
+        );
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        response = await client.GetAsync(Testing.Endpoints.Decisions.Get(mrn));
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        response = await client.GetAsync(Testing.Endpoints.Decisions.Comparison(mrn));
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var content = await response.Content.ReadAsStringAsync();
+
+        var result =
+            JsonSerializer.Deserialize<ComparisonEntity>(content, s_options)
+            ?? throw new Exception("Failed to deserialize");
+        result.Latest.AlvsXml.Should().Be(decisionOne);
+        result.Latest.IsFinalisation.Should().BeFalse();
+
+        await client.PutAsync(
+            Testing.Endpoints.Decisions.Alvs.Put(mrn),
+            new StringContent(decisionTwo, Encoding.UTF8, "application/xml")
+        );
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        response = await client.GetAsync(Testing.Endpoints.Decisions.Comparison(mrn));
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        content = await response.Content.ReadAsStringAsync();
+
+        result =
+            JsonSerializer.Deserialize<ComparisonEntity>(content, s_options)
+            ?? throw new Exception("Failed to deserialize");
+        result.Latest.AlvsXml.Should().Be(decisionTwo);
+        result.History.Count.Should().Be(1);
     }
 
     [Fact]

--- a/tests/Comparer.IntegrationTests/SqsTestBase.cs
+++ b/tests/Comparer.IntegrationTests/SqsTestBase.cs
@@ -8,7 +8,7 @@ namespace Defra.TradeImportsDecisionComparer.Comparer.IntegrationTests;
 public class SqsTestBase(ITestOutputHelper output) : IntegrationTestBase
 {
     private const string QueueUrl =
-        "http://sqs.eu-west-2.127.0.0.1:4566/000000000000/trade_imports_data_upserted_decision_comparer";
+        "http://sqs.eu-west-2.localhost.localstack.cloud:4566/000000000000/trade_imports_data_upserted_decision_comparer";
 
     private readonly AmazonSQSClient _sqsClient = new(
         new BasicAWSCredentials("test", "test"),

--- a/tests/Comparer.Tests/Comparision/ComparisonTests.cs
+++ b/tests/Comparer.Tests/Comparision/ComparisonTests.cs
@@ -152,4 +152,12 @@ public class ComparisonTests
 
         result.DecisionNumberMatched.Should().BeNull();
     }
+
+    [Fact]
+    public void WhenGivenDecisionToCompare_WhichDoesNotIncludeAFinalisation_IsFinalisationShouldBeFalse()
+    {
+        var result = Comparison.Create(SampleDecision, SampleDecision, null);
+
+        result.IsFinalisation.Should().BeFalse();
+    }
 }

--- a/tests/Comparer.Tests/Domain/ItemTests.cs
+++ b/tests/Comparer.Tests/Domain/ItemTests.cs
@@ -16,6 +16,20 @@ public class ItemTests
     }
 
     [Fact]
+    public void WhenXmlHasNoItems_ReturnEmptyList()
+    {
+        var result = Item.FromXml(
+            @"<?xml version=""1.0"" encoding=""UTF-8""?>
+              <NS1:Envelope xmlns:NS1=""http://www.w3.org/2003/05/soap-envelope"">
+                  <NS1:Body />
+              </NS1:Envelope>
+            "
+        );
+
+        result.Count.Should().Be(0);
+    }
+
+    [Fact]
     public void WhenXmlIsHasValue_ReturnItems()
     {
         var result = Item.FromXml(SampleDecision);

--- a/tests/Comparer.Tests/Domain/ServiceHeaderTests.cs
+++ b/tests/Comparer.Tests/Domain/ServiceHeaderTests.cs
@@ -13,4 +13,18 @@ public class ServiceHeaderTests
         var serviceHeader = ServiceHeader.FromXml(SampleDecision);
         serviceHeader.ServiceCallTimestamp.Should().Be(new DateTime(2025, 05, 29, 18, 57, 29, 298, DateTimeKind.Utc));
     }
+
+    [Fact]
+    public void WhenXmlHasNoServiceHeader_ReturnEmptyServiceHeader()
+    {
+        var result = ServiceHeader.FromXml(
+            @"<?xml version=""1.0"" encoding=""UTF-8""?>
+              <NS1:Envelope xmlns:NS1=""http://www.w3.org/2003/05/soap-envelope"">
+                  <NS1:Body />
+              </NS1:Envelope>
+            "
+        );
+
+        result.ServiceCallTimestamp.Should().BeNull();
+    }
 }


### PR DESCRIPTION
We do not want to generate decisions just on a finalisation, because that is too late.
This updates the endpoint for receiving ALVS decisions to also generate a comparison.