### PR TITLE
CDMS-657: Add isFinalisation query

### DIFF
--- a/src/Comparer/Endpoints/Decisions/EndpointRouteBuilderExtensions.cs
+++ b/src/Comparer/Endpoints/Decisions/EndpointRouteBuilderExtensions.cs
@@ -63,10 +63,11 @@ public static class EndpointRouteBuilderExtensions
         [FromQuery] DateTime? start,
         [FromQuery] DateTime? end,
         [FromServices] IParityService parityService,
-        CancellationToken cancellationToken
+        [FromQuery] bool? isFinalisation = true,
+        CancellationToken cancellationToken = default
     )
     {
-        var parity = await parityService.Get(start, end, cancellationToken);
+        var parity = await parityService.Get(start, end, isFinalisation != false, cancellationToken);
 
         return Results.Ok(parity);
     }

--- a/src/Comparer/Services/IParityService.cs
+++ b/src/Comparer/Services/IParityService.cs
@@ -4,5 +4,10 @@ namespace Defra.TradeImportsDecisionComparer.Comparer.Services;
 
 public interface IParityService
 {
-    Task<ParityProjection> Get(DateTime? start, DateTime? end, CancellationToken cancellationToken);
+    Task<ParityProjection> Get(
+        DateTime? start,
+        DateTime? end,
+        bool isFinalisation,
+        CancellationToken cancellationToken
+    );
 }

--- a/src/Comparer/Services/ParityService.cs
+++ b/src/Comparer/Services/ParityService.cs
@@ -9,9 +9,20 @@ namespace Defra.TradeImportsDecisionComparer.Comparer.Services;
 [ExcludeFromCodeCoverage] // see integration tests
 public class ParityService(IDbContext dbContext) : IParityService
 {
-    public async Task<ParityProjection> Get(DateTime? start, DateTime? end, CancellationToken cancellationToken)
+    public async Task<ParityProjection> Get(
+        DateTime? start,
+        DateTime? end,
+        bool isFinalisation,
+        CancellationToken cancellationToken
+    )
     {
         var query = from c in dbContext.Comparisons select c;
+
+        query = isFinalisation switch
+        {
+            true => from c in query where c.Latest.IsFinalisation == true || c.Latest.IsFinalisation == null select c,
+            false => from c in query where c.Latest.IsFinalisation == false select c,
+        };
 
         if (start.HasValue)
         {

--- a/tests/Comparer.Tests/Endpoints/Decisions/ParityTests.cs
+++ b/tests/Comparer.Tests/Endpoints/Decisions/ParityTests.cs
@@ -46,7 +46,7 @@ public class ParityTests(ComparerWebApplicationFactory factory, ITestOutputHelpe
     {
         var client = CreateClient();
         MockParityService
-            .Get(null, null, Arg.Any<CancellationToken>())
+            .Get(null, null, true, Arg.Any<CancellationToken>())
             .Returns(
                 new ParityProjection(new Dictionary<string, int> { { nameof(ComparisionOutcome.Mismatch), 3 } }, [Mrn])
             );
@@ -59,5 +59,22 @@ public class ParityTests(ComparerWebApplicationFactory factory, ITestOutputHelpe
             .UseStrictJson()
             .DontIgnoreEmptyCollections()
             .DontScrubDateTimes();
+    }
+
+    [Fact]
+    public async Task Get_WithIsFinalisationFalse_ShouldQueryWithIsFinalisationFalse()
+    {
+        var client = CreateClient();
+        MockParityService
+            .Get(null, null, false, Arg.Any<CancellationToken>())
+            .Returns(
+                new ParityProjection(new Dictionary<string, int> { { nameof(ComparisionOutcome.Mismatch), 3 } }, [Mrn])
+            );
+
+        var response = await client.GetAsync(Testing.Endpoints.Decisions.Parity(null, null, false));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        await MockParityService.Received(1).Get(null, null, false, Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Testing/Endpoints.cs
+++ b/tests/Testing/Endpoints.cs
@@ -13,7 +13,7 @@ public static class Endpoints
 
         public static string Comparison(string mrn) => $"{Get(mrn)}/comparison";
 
-        public static string Parity(DateTime? start, DateTime? end)
+        public static string Parity(DateTime? start, DateTime? end, bool? isFinalisation = true)
         {
             var queryString = QueryString.Empty;
 
@@ -25,6 +25,11 @@ public static class Endpoints
             if (end.HasValue)
             {
                 queryString = queryString.Add(nameof(end), end.Value.ToString("O", CultureInfo.InvariantCulture));
+            }
+
+            if (isFinalisation.HasValue)
+            {
+                queryString = queryString.Add(nameof(isFinalisation), isFinalisation.Value.ToString());
             }
 
             return $"{Root()}/parity{queryString.Value}";


### PR DESCRIPTION
We currently store comparisons for finalised and non-finalised decisions which are used separately for reporting purposes. This adds an optional query, defaulting to true which is the current behavior, to allow the user to only query for non-finalised (in-flight) decisions.