### PR TITLE
CDMS-657: Add received sequence count for matching decision numbers to parity endpoint

### DIFF
--- a/src/Comparer/Domain/Header.cs
+++ b/src/Comparer/Domain/Header.cs
@@ -36,9 +36,9 @@ public record Header(
 
         var entryVersionNumber = TryParse(
             xmlElement.GetValueOrDefault(nameof(ElementNames.EntryVersionNumber), ""),
-            out var entryVersionNumbeParsed
+            out var entryVersionNumberParsed
         )
-            ? entryVersionNumbeParsed
+            ? entryVersionNumberParsed
             : (int?)null;
 
         return new Header(decisionNumber, entryVersionNumber);

--- a/tests/Comparer.Tests/Endpoints/Decisions/ParityTests.Get_WhenAuthorized_ShouldBeOk.verified.json
+++ b/tests/Comparer.Tests/Endpoints/Decisions/ParityTests.Get_WhenAuthorized_ShouldBeOk.verified.json
@@ -3,7 +3,9 @@
     "Mismatch": 3
   },
   "decisionNumberStats": {
-    "Mismatch": 3
+    "Mismatch": 3,
+    "countWhereAlvsRespondedFirst": 1,
+    "countWhereBtmsRespondedFirst": 2
   },
   "misMatchMrns": [
     "mrn"

--- a/tests/Comparer.Tests/Endpoints/Decisions/ParityTests.cs
+++ b/tests/Comparer.Tests/Endpoints/Decisions/ParityTests.cs
@@ -50,7 +50,12 @@ public class ParityTests(ComparerWebApplicationFactory factory, ITestOutputHelpe
             .Returns(
                 new ParityProjection(
                     new Dictionary<string, int> { { nameof(ComparisionOutcome.Mismatch), 3 } },
-                    new Dictionary<string, int> { { nameof(DecisionNumberMatch.Mismatch), 3 } },
+                    new Dictionary<string, int>
+                    {
+                        { nameof(DecisionNumberMatch.Mismatch), 3 },
+                        { "countWhereAlvsRespondedFirst", 1 },
+                        { "countWhereBtmsRespondedFirst", 2 },
+                    },
                     [Mrn],
                     [Mrn]
                 )


### PR DESCRIPTION
When we have matching decision numbers, we'd like to know how many decisions were made by BTMS first.