### PR TITLE
Move comparison call so it's executed within the save try/catch

### DIFF
--- a/src/Comparer/Consumers/FinalisationsConsumer.cs
+++ b/src/Comparer/Consumers/FinalisationsConsumer.cs
@@ -20,7 +20,7 @@ public class FinalisationsConsumer(IComparisonManager comparisonManager, ILogger
         logger.LogInformation("Received finalisation for {ResourceId}", message.ResourceId);
 
         var finalisation = message.Resource?.Finalisation;
-        await comparisonManager.CreateUpdateComparisonEntity(message.ResourceId, finalisation, cancellationToken);
+        await comparisonManager.CompareLatestDecisions(message.ResourceId, finalisation, cancellationToken);
     }
 
     public required IConsumerContext Context { get; set; }

--- a/src/Comparer/Endpoints/Decisions/EndpointRouteBuilderExtensions.cs
+++ b/src/Comparer/Endpoints/Decisions/EndpointRouteBuilderExtensions.cs
@@ -26,16 +26,16 @@ public static class EndpointRouteBuilderExtensions
         [FromServices] IDecisionService decisionService,
         [FromServices] IComparisonManager comparisonManager,
         CancellationToken cancellationToken
-    )
-    {
-        var result = await ReadAndSave(
+    ) =>
+        await ReadAndSave(
             context,
-            (d, ct) => decisionService.AppendAlvsDecision(mrn, d, ct),
+            async (decision, ct) =>
+            {
+                await decisionService.AppendAlvsDecision(mrn, decision, ct);
+                await comparisonManager.CompareLatestDecisions(mrn, null, ct);
+            },
             cancellationToken
         );
-        await comparisonManager.CreateUpdateComparisonEntity(mrn, null, cancellationToken);
-        return result;
-    }
 
     [HttpPut]
     private static async Task<IResult> PutBtms(

--- a/src/Comparer/Services/ComparisonManager.cs
+++ b/src/Comparer/Services/ComparisonManager.cs
@@ -13,7 +13,7 @@ public class ComparisonManager(
     IOutboundErrorService outboundErrorService
 ) : IComparisonManager
 {
-    public async Task CreateUpdateComparisonEntity(
+    public async Task CompareLatestDecisions(
         string mrn,
         Finalisation? finalisation,
         CancellationToken cancellationToken

--- a/src/Comparer/Services/IComparisonManager.cs
+++ b/src/Comparer/Services/IComparisonManager.cs
@@ -4,11 +4,7 @@ namespace Defra.TradeImportsDecisionComparer.Comparer.Services;
 
 public interface IComparisonManager
 {
-    public Task CreateUpdateComparisonEntity(
-        string mrn,
-        Finalisation? finalisation,
-        CancellationToken cancellationToken
-    );
+    public Task CompareLatestDecisions(string mrn, Finalisation? finalisation, CancellationToken cancellationToken);
 
     public Task CompareLatestOutboundErrors(string mrn, CancellationToken cancellationToken);
 }

--- a/tests/Comparer.Tests/Endpoints/Decisions/PutTests.cs
+++ b/tests/Comparer.Tests/Endpoints/Decisions/PutTests.cs
@@ -71,7 +71,7 @@ public class PutTests(ComparerWebApplicationFactory factory, ITestOutputHelper o
         );
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        await MockComparisonManager.Received().CreateUpdateComparisonEntity(Mrn, null, Arg.Any<CancellationToken>());
+        await MockComparisonManager.Received().CompareLatestDecisions(Mrn, null, Arg.Any<CancellationToken>());
     }
 
     [Fact]


### PR DESCRIPTION
As per PR title.

If a conflict is thrown during save then it will return as such now, whereas before it would have resulted in an unhandled exception.