### PR TITLE
When in connected silent running, rewrite unhandled exception when present for a PUT endpoint to a 200 OK regardless of the outcome. Also log the detail

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -46,6 +46,7 @@ services:
       Acl__Clients__IntegrationTests__Secret: integration-tests-pwd
       Acl__Clients__IntegrationTests__Scopes__0: read
       Acl__Clients__IntegrationTests__Scopes__1: write
+      Btms__ConnectedSilentRunning: false
     ports:
       - "8080:8080"
     healthcheck:

--- a/src/Comparer/Configuration/BtmsOptions.cs
+++ b/src/Comparer/Configuration/BtmsOptions.cs
@@ -1,0 +1,6 @@
+namespace Defra.TradeImportsDecisionComparer.Comparer.Configuration;
+
+public class BtmsOptions
+{
+    public bool ConnectedSilentRunning { get; init; } = true;
+}

--- a/src/Comparer/Program.cs
+++ b/src/Comparer/Program.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using Defra.TradeImportsDecisionComparer.Comparer.Authentication;
+using Defra.TradeImportsDecisionComparer.Comparer.Configuration;
 using Defra.TradeImportsDecisionComparer.Comparer.Data.Extensions;
 using Defra.TradeImportsDecisionComparer.Comparer.Endpoints.Decisions;
 using Defra.TradeImportsDecisionComparer.Comparer.Endpoints.OutboundErrors;
@@ -12,6 +13,7 @@ using Defra.TradeImportsDecisionComparer.Comparer.Utils.Logging;
 using Elastic.CommonSchema.Serilog;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.Extensions.Http.Resilience;
+using Microsoft.Extensions.Options;
 using Polly;
 using Serilog;
 
@@ -85,6 +87,7 @@ static void ConfigureWebApplication(WebApplicationBuilder builder, string[] args
             }
         );
     });
+    builder.Services.AddOptions<BtmsOptions>().BindConfiguration("Btms").ValidateOptions();
     builder.Services.AddProblemDetails();
     builder.Services.AddHealthChecks();
     builder.Services.AddHealth(builder.Configuration);
@@ -130,6 +133,27 @@ static WebApplication BuildWebApplication(WebApplicationBuilder builder)
                 {
                     context.Response.StatusCode = badHttpRequestException.StatusCode;
                     detail = badHttpRequestException.Message;
+                }
+
+                var btmsOptions = context.RequestServices.GetRequiredService<IOptions<BtmsOptions>>().Value;
+                if (btmsOptions.ConnectedSilentRunning && error is not null)
+                {
+                    var httpMethodMetadata =
+                        exceptionHandlerFeature?.Endpoint?.Metadata.GetMetadata<HttpMethodMetadata>();
+                    if (httpMethodMetadata != null && httpMethodMetadata.HttpMethods.Contains("PUT"))
+                    {
+                        var logger = context
+                            .RequestServices.GetRequiredService<ILoggerFactory>()
+                            .CreateLogger("ExceptionHandler");
+
+                        logger.LogWarning(
+                            error,
+                            "Exception from endpoint {Endpoint} during connected silent running",
+                            exceptionHandlerFeature?.Endpoint?.DisplayName
+                        );
+
+                        context.Response.StatusCode = StatusCodes.Status200OK;
+                    }
                 }
 
                 await context

--- a/src/Comparer/Program.cs
+++ b/src/Comparer/Program.cs
@@ -136,10 +136,10 @@ static WebApplication BuildWebApplication(WebApplicationBuilder builder)
                 }
 
                 var btmsOptions = context.RequestServices.GetRequiredService<IOptions<BtmsOptions>>().Value;
-                if (btmsOptions.ConnectedSilentRunning && error is not null)
+                if (btmsOptions.ConnectedSilentRunning && exceptionHandlerFeature is not null && error is not null)
                 {
                     var httpMethodMetadata =
-                        exceptionHandlerFeature?.Endpoint?.Metadata.GetMetadata<HttpMethodMetadata>();
+                        exceptionHandlerFeature.Endpoint?.Metadata.GetMetadata<HttpMethodMetadata>();
                     if (httpMethodMetadata != null && httpMethodMetadata.HttpMethods.Contains("PUT"))
                     {
                         var logger = context
@@ -149,7 +149,7 @@ static WebApplication BuildWebApplication(WebApplicationBuilder builder)
                         logger.LogWarning(
                             error,
                             "Exception from endpoint {Endpoint} during connected silent running",
-                            exceptionHandlerFeature?.Endpoint?.DisplayName
+                            exceptionHandlerFeature.Endpoint?.DisplayName
                         );
 
                         context.Response.StatusCode = StatusCodes.Status200OK;

--- a/tests/Comparer.Tests/Endpoints/Decisions/PutTests.cs
+++ b/tests/Comparer.Tests/Endpoints/Decisions/PutTests.cs
@@ -75,6 +75,22 @@ public class PutTests(ComparerWebApplicationFactory factory, ITestOutputHelper o
     }
 
     [Fact]
+    public async Task PutAlvs_WhenComparisonManagerThrows_AndConnectedSilentRunning_ShouldBeOk()
+    {
+        var client = CreateClient();
+        MockComparisonManager
+            .CompareLatestOutboundErrors(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Throws(new Exception("Unhandled"));
+
+        var response = await client.PutAsync(
+            Testing.Endpoints.Decisions.Alvs.Put(Mrn),
+            new StringContent("<xml alvs=\"true\" />")
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
     public async Task PutAlvs_WhenConcurrencyException_ShouldBeConflict()
     {
         var client = CreateClient();
@@ -124,6 +140,22 @@ public class PutTests(ComparerWebApplicationFactory factory, ITestOutputHelper o
         var content = await response.Content.ReadAsStringAsync();
 
         await Verify(content);
+    }
+
+    [Fact]
+    public async Task PutBtms_WhenDecisionServiceThrows_AndConnectedSilentRunning_ShouldBeOk()
+    {
+        var client = CreateClient();
+        MockDecisionService
+            .AppendBtmsDecision(Arg.Any<string>(), Arg.Any<Decision>(), Arg.Any<CancellationToken>())
+            .Throws(new Exception("Unhandled"));
+
+        var response = await client.PutAsync(
+            Testing.Endpoints.Decisions.Btms.Put(Mrn),
+            new StringContent("<xml btms=\"true\" />")
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [Fact]

--- a/tests/Comparer.Tests/Endpoints/OutboundErrors/PutTests.cs
+++ b/tests/Comparer.Tests/Endpoints/OutboundErrors/PutTests.cs
@@ -69,6 +69,22 @@ public class PutTests(ComparerWebApplicationFactory factory, ITestOutputHelper o
     }
 
     [Fact]
+    public async Task PutAlvs_WhenComparisonManagerThrows_AndConnectedSilentRunning_ShouldBeOk()
+    {
+        var client = CreateClient();
+        MockComparisonManager
+            .CompareLatestOutboundErrors(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Throws(new Exception("Unhandled"));
+
+        var response = await client.PutAsync(
+            Testing.Endpoints.OutboundErrors.Alvs.Put(Mrn),
+            new StringContent("<xml alvs=\"true\" />")
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
     public async Task PutAlvs_WhenConcurrencyException_ShouldBeConflict()
     {
         var client = CreateClient();
@@ -126,6 +142,22 @@ public class PutTests(ComparerWebApplicationFactory factory, ITestOutputHelper o
         await Verify(content);
 
         await MockComparisonManager.Received().CompareLatestOutboundErrors(Mrn, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PutBtms_WhenComparisonManagerThrows_AndConnectedSilentRunning_ShouldBeOk()
+    {
+        var client = CreateClient();
+        MockComparisonManager
+            .CompareLatestOutboundErrors(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Throws(new Exception("Unhandled"));
+
+        var response = await client.PutAsync(
+            Testing.Endpoints.OutboundErrors.Btms.Put(Mrn),
+            new StringContent("<xml alvs=\"true\" />")
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [Fact]


### PR DESCRIPTION
Before this change, the comparer could return an unhandled exception, which would translate to a non success response code that the gateway would then log as an error.

During normal operation this would be OK but during connected silent running we don't want to affect the operation of the gateway.

Therefore, this PR adds custom exception handling for PUT endpoints, which kicks in if there is an error and it will ensure a 200 response code. 

The comparer will still log all the detail, which can review should anything unexpected arise.

There is a config setting that can be used if needed to disable the behaviour and the integration tests still run against an instance of the comparer that is not in "connected silent running" mode.

The in memory integration/endpoint tests are in connected silent running mode and there are tests to show the response code mapping is taking place when exceptions are thrown.