### PR TITLE
Report metrics for decision comparisons

### DIFF
--- a/src/Comparer/Metrics/ComparisonMetrics.cs
+++ b/src/Comparer/Metrics/ComparisonMetrics.cs
@@ -1,0 +1,64 @@
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Metrics;
+using Amazon.CloudWatch.EMF.Model;
+
+namespace Defra.TradeImportsDecisionComparer.Comparer.Metrics;
+
+[ExcludeFromCodeCoverage]
+public class ComparisonMetrics : IComparisonMetrics
+{
+    private readonly Counter<long> _total;
+    private readonly Counter<long> _totalBtms;
+    private readonly Counter<long> _totalAlvs;
+
+    public ComparisonMetrics(IMeterFactory meterFactory)
+    {
+        var meter = meterFactory.Create(MetricsConstants.MetricNames.MeterName);
+
+        _total = meter.CreateCounter<long>(
+            "ComparisonTotal",
+            nameof(Unit.COUNT),
+            description: "Total decisions compared"
+        );
+        _totalBtms = meter.CreateCounter<long>(
+            "ComparisonTotalBtms",
+            nameof(Unit.COUNT),
+            description: "Total BTMS decisions"
+        );
+        _totalAlvs = meter.CreateCounter<long>(
+            "ComparisonTotalAlvs",
+            nameof(Unit.COUNT),
+            description: "Total ALVS decisions"
+        );
+    }
+
+    public void BtmsDecision()
+    {
+        var tagList = BuildTags();
+
+        _total.Add(1, tagList);
+        _totalBtms.Add(1, tagList);
+    }
+
+    public void AlvsDecision()
+    {
+        var tagList = BuildTags();
+
+        _total.Add(1, tagList);
+        _totalAlvs.Add(1, tagList);
+    }
+
+    private static TagList BuildTags()
+    {
+        return new TagList { { Constants.Tags.Service, Process.GetCurrentProcess().ProcessName } };
+    }
+
+    private static class Constants
+    {
+        public static class Tags
+        {
+            public const string Service = "ServiceName";
+        }
+    }
+}

--- a/src/Comparer/Metrics/ConsumerMetrics.cs
+++ b/src/Comparer/Metrics/ConsumerMetrics.cs
@@ -64,6 +64,7 @@ public class ConsumerMetrics
         var tagList = BuildTags(queueName, consumerName, resourceType, subResourceType);
 
         tagList.Add(Constants.Tags.ExceptionType, exception.GetType().Name);
+
         _consumeFaultTotal.Add(1, tagList);
     }
 
@@ -78,6 +79,7 @@ public class ConsumerMetrics
         var tagList = BuildTags(queueName, consumerName, resourceType, subResourceType);
 
         tagList.Add(Constants.Tags.ExceptionType, exception.GetType().Name);
+
         _consumeWarnTotal.Add(1, tagList);
     }
 

--- a/src/Comparer/Metrics/IComparisonMetrics.cs
+++ b/src/Comparer/Metrics/IComparisonMetrics.cs
@@ -1,0 +1,8 @@
+namespace Defra.TradeImportsDecisionComparer.Comparer.Metrics;
+
+public interface IComparisonMetrics
+{
+    void BtmsDecision();
+
+    void AlvsDecision();
+}

--- a/src/Comparer/Metrics/RequestMetrics.cs
+++ b/src/Comparer/Metrics/RequestMetrics.cs
@@ -6,40 +6,42 @@ namespace Defra.TradeImportsDecisionComparer.Comparer.Metrics;
 
 public class RequestMetrics
 {
-    private readonly Counter<long> requestsReceived;
-    private readonly Counter<long> requestsFaulted;
-    private readonly Histogram<double> requestDuration;
+    private readonly Counter<long> _requestsReceived;
+    private readonly Counter<long> _requestsFaulted;
+    private readonly Histogram<double> _requestDuration;
 
     public RequestMetrics(IMeterFactory meterFactory)
     {
         var meter = meterFactory.Create(MetricsConstants.MetricNames.MeterName);
 
-        requestsReceived = meter.CreateCounter<long>(
+        _requestsReceived = meter.CreateCounter<long>(
             "RequestReceived",
-            Unit.COUNT.ToString(),
+            nameof(Unit.COUNT),
             "Count of messages received"
         );
 
-        requestDuration = meter.CreateHistogram<double>(
+        _requestDuration = meter.CreateHistogram<double>(
             "RequestDuration",
-            Unit.MILLISECONDS.ToString(),
+            nameof(Unit.MILLISECONDS),
             "Duration of request"
         );
 
-        requestsFaulted = meter.CreateCounter<long>("RequestFaulted", Unit.COUNT.ToString(), "Count of request faults");
+        _requestsFaulted = meter.CreateCounter<long>("RequestFaulted", nameof(Unit.COUNT), "Count of request faults");
     }
 
     public void RequestCompleted(string requestPath, string httpMethod, int statusCode, double milliseconds)
     {
-        requestsReceived.Add(1, BuildTags(requestPath, httpMethod, statusCode));
-        requestDuration.Record(milliseconds, BuildTags(requestPath, httpMethod, statusCode));
+        _requestsReceived.Add(1, BuildTags(requestPath, httpMethod, statusCode));
+        _requestDuration.Record(milliseconds, BuildTags(requestPath, httpMethod, statusCode));
     }
 
     public void RequestFaulted(string requestPath, string httpMethod, int statusCode, Exception exception)
     {
         var tagList = BuildTags(requestPath, httpMethod, statusCode);
+
         tagList.Add(MetricsConstants.RequestTags.ExceptionType, exception.GetType().Name);
-        requestsFaulted.Add(1, tagList);
+
+        _requestsFaulted.Add(1, tagList);
     }
 
     private static TagList BuildTags(string requestPath, string httpMethod, int statusCode)

--- a/src/Comparer/Program.cs
+++ b/src/Comparer/Program.cs
@@ -112,6 +112,7 @@ static void ConfigureWebApplication(WebApplicationBuilder builder, string[] args
             _ => new DefaultOperatingModeStrategy(),
         }
     );
+    builder.Services.AddSingleton<IComparisonMetrics, ComparisonMetrics>();
 
     builder.Services.AddTransient<MetricsMiddleware>();
     builder.Services.AddSingleton<RequestMetrics>();

--- a/src/Comparer/Services/TrialCutoverOperatingModeStrategy.cs
+++ b/src/Comparer/Services/TrialCutoverOperatingModeStrategy.cs
@@ -1,11 +1,14 @@
 using Defra.TradeImportsDecisionComparer.Comparer.Comparision;
 using Defra.TradeImportsDecisionComparer.Comparer.Domain;
 using Defra.TradeImportsDecisionComparer.Comparer.Entities;
+using Defra.TradeImportsDecisionComparer.Comparer.Metrics;
 
 namespace Defra.TradeImportsDecisionComparer.Comparer.Services;
 
-public class TrialCutoverOperatingModeStrategy(ILogger<TrialCutoverOperatingModeStrategy> logger)
-    : IOperatingModeStrategy
+public class TrialCutoverOperatingModeStrategy(
+    ILogger<TrialCutoverOperatingModeStrategy> logger,
+    IComparisonMetrics comparisonMetrics
+) : IOperatingModeStrategy
 {
     public string DetermineDecision(ComparisonEntity comparison, Decision incomingDecision)
     {
@@ -29,6 +32,8 @@ public class TrialCutoverOperatingModeStrategy(ILogger<TrialCutoverOperatingMode
             comparison.Latest.Created
         );
 
+        comparisonMetrics.BtmsDecision();
+
         return comparison.Latest.BtmsXml!;
     }
 
@@ -39,6 +44,8 @@ public class TrialCutoverOperatingModeStrategy(ILogger<TrialCutoverOperatingMode
             comparison.Id,
             comparison.Latest.Created
         );
+
+        comparisonMetrics.AlvsDecision();
 
         return incomingDecision.Xml;
     }

--- a/tests/Comparer.Tests/Endpoints/Decisions/PutTests/ConnectedSilentRunningTests.cs
+++ b/tests/Comparer.Tests/Endpoints/Decisions/PutTests/ConnectedSilentRunningTests.cs
@@ -68,6 +68,9 @@ public class ConnectedSilentRunningTests(ComparerWebApplicationFactory factory, 
     public async Task PutAlvs_WhenValid_ShouldTriggerAComparison()
     {
         var client = CreateClient();
+        MockComparisonManager
+            .CompareLatestDecisions(Mrn, null, Arg.Any<CancellationToken>())
+            .Returns(new ComparisonEntity { Id = Mrn, Latest = Comparison.Empty });
 
         var response = await client.PutAsync(
             Testing.Endpoints.Decisions.Alvs.Put(Mrn),


### PR DESCRIPTION
This can be merged without production impact.

Counts for choosing the BTMS decision or ALVS decision are collected, as well as an overall count for the amount of decision checks made.

These will be used to power a simple dashboard in Grafana.