### PR TITLE
Add sampling to decision selection for trial cutover

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -77,6 +77,7 @@ services:
       Acl__Clients__IntegrationTests__Scopes__0: read
       Acl__Clients__IntegrationTests__Scopes__1: write
       Btms__OperatingMode: 2 # TrialCutover
+      Btms__DecisionSamplingPercentage: 100
       FinalisationsConsumer__QueueName: trade_imports_data_upserted_decision_comparer_trialcutover
     ports:
       - "8081:8081"

--- a/src/Comparer/Configuration/BtmsOptions.cs
+++ b/src/Comparer/Configuration/BtmsOptions.cs
@@ -1,6 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Defra.TradeImportsDecisionComparer.Comparer.Configuration;
 
 public class BtmsOptions
 {
+    public const string SectionName = "Btms";
+
     public OperatingMode OperatingMode { get; init; } = OperatingMode.ConnectedSilentRunning;
+
+    [Range(0, 100)]
+    public int DecisionSamplingPercentage { get; init; }
 }

--- a/src/Comparer/Program.cs
+++ b/src/Comparer/Program.cs
@@ -87,7 +87,7 @@ static void ConfigureWebApplication(WebApplicationBuilder builder, string[] args
             }
         );
     });
-    builder.Services.AddOptions<BtmsOptions>().BindConfiguration("Btms").ValidateOptions();
+    builder.Services.AddOptions<BtmsOptions>().BindConfiguration(BtmsOptions.SectionName).ValidateOptions();
     builder.Services.AddProblemDetails();
     builder.Services.AddHealthChecks();
     builder.Services.AddHealth(builder.Configuration);
@@ -113,6 +113,7 @@ static void ConfigureWebApplication(WebApplicationBuilder builder, string[] args
         }
     );
     builder.Services.AddSingleton<IComparisonMetrics, ComparisonMetrics>();
+    builder.Services.AddSingleton<IRandom, RandomShared>();
 
     builder.Services.AddTransient<MetricsMiddleware>();
     builder.Services.AddSingleton<RequestMetrics>();

--- a/src/Comparer/Properties/launchSettings.json
+++ b/src/Comparer/Properties/launchSettings.json
@@ -13,7 +13,6 @@
         "AWS_SECRET_ACCESS_KEY": "test",
         "ENVIRONMENT": "local",
         "SQS_ENDPOINT": "http://localhost:4566",
-
         "Acl__Clients__IntegrationTests__Secret": "integration-tests-pwd",
         "Acl__Clients__IntegrationTests__Scopes__0": "read",
         "Acl__Clients__IntegrationTests__Scopes__1": "write"

--- a/src/Comparer/Utils/IRandom.cs
+++ b/src/Comparer/Utils/IRandom.cs
@@ -1,0 +1,11 @@
+namespace Defra.TradeImportsDecisionComparer.Comparer.Utils;
+
+public interface IRandom
+{
+    double NextDouble();
+}
+
+public class RandomShared : IRandom
+{
+    public double NextDouble() => Random.Shared.NextDouble();
+}

--- a/tests/Comparer.Tests/Endpoints/Decisions/PutTests/TrialCutoverTests.cs
+++ b/tests/Comparer.Tests/Endpoints/Decisions/PutTests/TrialCutoverTests.cs
@@ -1,5 +1,4 @@
 using System.Net;
-using Defra.TradeImportsDecisionComparer.Comparer.Comparision;
 using Defra.TradeImportsDecisionComparer.Comparer.Configuration;
 using Defra.TradeImportsDecisionComparer.Comparer.Domain;
 using Defra.TradeImportsDecisionComparer.Comparer.Entities;
@@ -33,7 +32,13 @@ public class TrialCutoverTests(ComparerWebApplicationFactory factory, ITestOutpu
         base.ConfigureHostConfiguration(config);
 
         config.AddInMemoryCollection(
-            new Dictionary<string, string?> { ["Btms:OperatingMode"] = ((int)OperatingMode.TrialCutover).ToString() }
+            new Dictionary<string, string?>
+            {
+                [$"{BtmsOptions.SectionName}:{nameof(BtmsOptions.OperatingMode)}"] = (
+                    (int)OperatingMode.TrialCutover
+                ).ToString(),
+                [$"{BtmsOptions.SectionName}:{nameof(BtmsOptions.DecisionSamplingPercentage)}"] = "100",
+            }
         );
     }
 


### PR DESCRIPTION
As per PR title.

The trial cutover logic for decision selection now allows a sampling percentage to be specified.

It should be a numeric value between 0 and 100 inclusive.

If it's 0, then no BTMS decision will ever be sent.

If it's greater than 0 and less than or equal to 100 then it could be sent if the next system generated double * 100 is less than or equal to the configured percentage.

We can technically deploy to production in trial cutover mode with a sampling percentage of 0 and it will replicate silent running.