### PR TITLE
Enhance metrics being collected for trial cutover

### DIFF
--- a/src/Comparer/Metrics/ComparisonMetrics.cs
+++ b/src/Comparer/Metrics/ComparisonMetrics.cs
@@ -14,6 +14,7 @@ public class ComparisonMetrics : IComparisonMetrics
     private readonly Counter<long> _alvsDecisions;
     private readonly Counter<long> _sampled;
     private readonly Gauge<int> _samplingPercentage;
+    private readonly Counter<long> _match;
 
     public ComparisonMetrics(IMeterFactory meterFactory)
     {
@@ -40,6 +41,7 @@ public class ComparisonMetrics : IComparisonMetrics
             nameof(Unit.NONE),
             description: "Current sampling percentage"
         );
+        _match = meter.CreateCounter<long>("ComparisonMatch", nameof(Unit.COUNT), description: "Matched decisions");
     }
 
     public void BtmsDecision()
@@ -67,6 +69,8 @@ public class ComparisonMetrics : IComparisonMetrics
 
         if (decisionNumberMatch is not null)
             tagList.Add(Constants.Tags.DecisionNumberMatch, decisionNumberMatch.ToString());
+
+        _match.Add(1, tagList);
     }
 
     public void Sampled(bool sampled, int percentage)

--- a/src/Comparer/Metrics/IComparisonMetrics.cs
+++ b/src/Comparer/Metrics/IComparisonMetrics.cs
@@ -1,3 +1,5 @@
+using Defra.TradeImportsDecisionComparer.Comparer.Comparision;
+
 namespace Defra.TradeImportsDecisionComparer.Comparer.Metrics;
 
 public interface IComparisonMetrics
@@ -5,4 +7,8 @@ public interface IComparisonMetrics
     void BtmsDecision();
 
     void AlvsDecision();
+
+    void Match(bool match, ComparisionOutcome comparisionOutcome, DecisionNumberMatch? decisionNumberMatch);
+
+    void Sampled(bool sampled, int percentage);
 }

--- a/src/Comparer/Services/TrialCutoverOperatingModeStrategy.cs
+++ b/src/Comparer/Services/TrialCutoverOperatingModeStrategy.cs
@@ -25,15 +25,27 @@ public class TrialCutoverOperatingModeStrategy(
         return UseIncomingDecision(comparison, incomingDecision);
     }
 
-    private bool IsSamplingReached() =>
-        btmsOptions.Value.DecisionSamplingPercentage > 0
-        && random.NextDouble() * 100 <= btmsOptions.Value.DecisionSamplingPercentage;
-
-    private static bool DecisionMatches(ComparisonEntity comparison)
+    private bool IsSamplingReached()
     {
-        return comparison.Latest
+        var result =
+            btmsOptions.Value.DecisionSamplingPercentage > 0
+            && random.NextDouble() * 100 <= btmsOptions.Value.DecisionSamplingPercentage;
+
+        comparisonMetrics.Sampled(result, btmsOptions.Value.DecisionSamplingPercentage);
+
+        return result;
+    }
+
+    private bool DecisionMatches(ComparisonEntity comparison)
+    {
+        var result =
+            comparison.Latest
                 is { Match: ComparisionOutcome.ExactMatch, DecisionNumberMatched: DecisionNumberMatch.ExactMatch }
             && !string.IsNullOrEmpty(comparison.Latest.BtmsXml);
+
+        comparisonMetrics.Match(result, comparison.Latest.Match, comparison.Latest.DecisionNumberMatched);
+
+        return result;
     }
 
     private string UseBtmsDecision(ComparisonEntity comparison)

--- a/tests/Comparer.IntegrationTests/Endpoints/DecisionParityTests.cs
+++ b/tests/Comparer.IntegrationTests/Endpoints/DecisionParityTests.cs
@@ -275,8 +275,7 @@ public class DecisionParityTests(ITestOutputHelper output) : SqsTestBase(output)
             new StringContent(btmsDecisionXml, Encoding.UTF8, "application/xml")
         );
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        Console.Write(alvsDecisionXml);
-        Console.Write(btmsDecisionXml);
+
         var message = new ResourceEvent<CustomsDeclaration>
         {
             ResourceId = mrn,

--- a/tests/Comparer.Tests/Services/TrialCutoverOperatingModeStrategyTests.cs
+++ b/tests/Comparer.Tests/Services/TrialCutoverOperatingModeStrategyTests.cs
@@ -46,7 +46,7 @@ public class TrialCutoverOperatingModeStrategyTests
         );
 
         result.Should().Be(incomingDecision.Xml);
-        AssertMetrics(alvsDecision: true);
+        AssertMetrics(alvsDecision: true, sampled: false);
     }
 
     [Fact]
@@ -65,7 +65,7 @@ public class TrialCutoverOperatingModeStrategyTests
         );
 
         result.Should().Be(incomingDecision.Xml);
-        AssertMetrics(alvsDecision: true);
+        AssertMetrics(alvsDecision: true, sampled: false);
     }
 
     [Theory]
@@ -83,7 +83,7 @@ public class TrialCutoverOperatingModeStrategyTests
         );
 
         result.Should().Be(incomingDecision.Xml);
-        AssertMetrics(alvsDecision: true);
+        AssertMetrics(alvsDecision: true, sampled: false);
     }
 
     [Theory]
@@ -120,7 +120,7 @@ public class TrialCutoverOperatingModeStrategyTests
         }
     }
 
-    private void AssertMetrics(bool btmsDecision = false, bool alvsDecision = false)
+    private void AssertMetrics(bool btmsDecision = false, bool alvsDecision = false, bool sampled = true)
     {
         if (btmsDecision)
             MockComparisonMetrics.Received(1).BtmsDecision();
@@ -131,6 +131,15 @@ public class TrialCutoverOperatingModeStrategyTests
             MockComparisonMetrics.Received(1).AlvsDecision();
         else
             MockComparisonMetrics.DidNotReceive().AlvsDecision();
+
+        MockComparisonMetrics
+            .Received(1)
+            .Match(Arg.Any<bool>(), Arg.Any<ComparisionOutcome>(), Arg.Any<DecisionNumberMatch?>());
+
+        if (sampled)
+            MockComparisonMetrics.Received(1).Sampled(Arg.Any<bool>(), Arg.Any<int>());
+        else
+            MockComparisonMetrics.DidNotReceive().Sampled(Arg.Any<bool>(), Arg.Any<int>());
     }
 
     private TrialCutoverOperatingModeStrategy CreateSubject(BtmsOptions? btmsOptions = null)


### PR DESCRIPTION
No functional change, just enhancing the metrics being collected so we have a chance of visualising more.

This change can be merged without affecting prod.