### PR TITLE
Move sampling percentage metric so it's called all the time

### DIFF
--- a/src/Comparer/Metrics/ComparisonMetrics.cs
+++ b/src/Comparer/Metrics/ComparisonMetrics.cs
@@ -48,7 +48,8 @@ public class ComparisonMetrics : IComparisonMetrics
     {
         var tagList = BuildTags();
 
-        IncrementTotal(tagList);
+        AddDecision(tagList);
+
         _btmsDecisions.Add(1, tagList);
     }
 
@@ -56,7 +57,8 @@ public class ComparisonMetrics : IComparisonMetrics
     {
         var tagList = BuildTags();
 
-        IncrementTotal(tagList);
+        AddDecision(tagList);
+
         _alvsDecisions.Add(1, tagList);
     }
 
@@ -73,19 +75,20 @@ public class ComparisonMetrics : IComparisonMetrics
         _match.Add(1, tagList);
     }
 
-    public void Sampled(bool sampled, int percentage)
+    public void Sampled(bool sampled)
     {
         var tagList = BuildTags();
 
         tagList.Add(Constants.Tags.Sampled, sampled.ToString().ToLower());
 
         _sampled.Add(1, tagList);
-        _samplingPercentage.Record(percentage, tagList);
     }
+
+    public void SamplePercentage(int percentage) => _samplingPercentage.Record(percentage, BuildTags());
 
     private static TagList BuildTags() => new() { { Constants.Tags.Service, Process.GetCurrentProcess().ProcessName } };
 
-    private void IncrementTotal(TagList tagList) => _decisions.Add(1, tagList);
+    private void AddDecision(TagList tagList) => _decisions.Add(1, tagList);
 
     private static class Constants
     {

--- a/src/Comparer/Metrics/IComparisonMetrics.cs
+++ b/src/Comparer/Metrics/IComparisonMetrics.cs
@@ -10,5 +10,7 @@ public interface IComparisonMetrics
 
     void Match(bool match, ComparisionOutcome comparisionOutcome, DecisionNumberMatch? decisionNumberMatch);
 
-    void Sampled(bool sampled, int percentage);
+    void Sampled(bool sampled);
+
+    void SamplePercentage(int percentage);
 }

--- a/src/Comparer/Services/TrialCutoverOperatingModeStrategy.cs
+++ b/src/Comparer/Services/TrialCutoverOperatingModeStrategy.cs
@@ -17,6 +17,8 @@ public class TrialCutoverOperatingModeStrategy(
 {
     public string DetermineDecision(ComparisonEntity comparison, Decision incomingDecision)
     {
+        comparisonMetrics.SamplePercentage(btmsOptions.Value.DecisionSamplingPercentage);
+
         if (DecisionMatches(comparison) && IsSamplingReached())
         {
             return UseBtmsDecision(comparison);
@@ -31,7 +33,7 @@ public class TrialCutoverOperatingModeStrategy(
             btmsOptions.Value.DecisionSamplingPercentage > 0
             && random.NextDouble() * 100 <= btmsOptions.Value.DecisionSamplingPercentage;
 
-        comparisonMetrics.Sampled(result, btmsOptions.Value.DecisionSamplingPercentage);
+        comparisonMetrics.Sampled(result);
 
         return result;
     }

--- a/tests/Comparer.Tests/Services/TrialCutoverOperatingModeStrategyTests.cs
+++ b/tests/Comparer.Tests/Services/TrialCutoverOperatingModeStrategyTests.cs
@@ -137,9 +137,11 @@ public class TrialCutoverOperatingModeStrategyTests
             .Match(Arg.Any<bool>(), Arg.Any<ComparisionOutcome>(), Arg.Any<DecisionNumberMatch?>());
 
         if (sampled)
-            MockComparisonMetrics.Received(1).Sampled(Arg.Any<bool>(), Arg.Any<int>());
+            MockComparisonMetrics.Received(1).Sampled(Arg.Any<bool>());
         else
-            MockComparisonMetrics.DidNotReceive().Sampled(Arg.Any<bool>(), Arg.Any<int>());
+            MockComparisonMetrics.DidNotReceive().Sampled(Arg.Any<bool>());
+
+        MockComparisonMetrics.Received(1).SamplePercentage(Arg.Any<int>());
     }
 
     private TrialCutoverOperatingModeStrategy CreateSubject(BtmsOptions? btmsOptions = null)


### PR DESCRIPTION
As per PR title.

No functional change, just moving a metric call as previously it was within the `Sampled` method and this is only called if the decision matches.

Can be merged now as does not affect prod.