### PR TITLE
CDMS-568: All environments are Trial Cutover mode of 2 at sampling % of 0 (CDP app config can overwrite these defaults)

### DIFF
--- a/src/Comparer/Program.cs
+++ b/src/Comparer/Program.cs
@@ -150,7 +150,10 @@ static WebApplication BuildWebApplication(WebApplicationBuilder builder)
 
                 var btmsOptions = context.RequestServices.GetRequiredService<IOptions<BtmsOptions>>().Value;
                 if (
-                    btmsOptions.OperatingMode == OperatingMode.ConnectedSilentRunning
+                    (
+                        btmsOptions.OperatingMode == OperatingMode.ConnectedSilentRunning
+                        || btmsOptions is { OperatingMode: OperatingMode.TrialCutover, DecisionSamplingPercentage: 0 }
+                    )
                     && exceptionHandlerFeature is not null
                     && error is not null
                 )

--- a/src/Comparer/appsettings.json
+++ b/src/Comparer/appsettings.json
@@ -57,5 +57,10 @@
   },
   "FinalisationsConsumer": {
     "QueueName": "trade_imports_data_upserted_decision_comparer"
+  },
+  "Btms": {
+    "Comment": "All environments are Trial Cutover mode of 2 at sampling % of 0",
+    "OperatingMode": 2,
+    "DecisionSamplingPercentage": 0
   }
 }


### PR DESCRIPTION
As per PR title.

Default service config is now trial cutover with sampling percentage of 0.

The error silencing is also extended to include this setting as it's the same as connected silent running.